### PR TITLE
Cache subscriptions for a short amount of time

### DIFF
--- a/src/NServiceBus.NHibernate.PerformanceTests/NServiceBus.NHibernate.PerformanceTests.csproj
+++ b/src/NServiceBus.NHibernate.PerformanceTests/NServiceBus.NHibernate.PerformanceTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Saga\TestSaga.cs" />
     <Compile Include="Statistics.cs" />
     <Compile Include="StatisticsUoW.cs" />
+    <Compile Include="TestEvent.cs" />
     <Compile Include="TestMessage.cs" />
     <Compile Include="TestMessageHandler.cs" />
     <Compile Include="TestObject.cs" />

--- a/src/NServiceBus.NHibernate.PerformanceTests/Statistics.cs
+++ b/src/NServiceBus.NHibernate.PerformanceTests/Statistics.cs
@@ -11,30 +11,41 @@
         public static Int64 NumberOfRetries;
         public static TimeSpan SendTimeNoTx = TimeSpan.Zero;
         public static TimeSpan SendTimeWithTx = TimeSpan.Zero;
+        public static TimeSpan PublishTimeNoTx = TimeSpan.Zero;
+        public static TimeSpan PublishTimeWithTx = TimeSpan.Zero;
 
         public static void Dump()
         {
             Console.Out.WriteLine("");
             Console.Out.WriteLine("---------------- Statistics ----------------");
 
-            var durationSeconds = (Last - First.Value).TotalSeconds;
-
             PrintStats("NumberOfMessages", NumberOfMessages, "#");
 
-            var throughput = Convert.ToDouble(NumberOfMessages)/durationSeconds;
+            if (First.HasValue)
+            {
+                var durationSeconds = (Last - First.Value).TotalSeconds;
+                var throughput = Convert.ToDouble(NumberOfMessages) / durationSeconds;
 
-            PrintStats("Throughput", throughput, "msg/s");
+                PrintStats("Throughput", throughput, "msg/s");
 
-            Console.Out.WriteLine("##teamcity[buildStatisticValue key='ReceiveThroughputSagas' value='{0}']", Math.Round(throughput));
+                Console.Out.WriteLine("##teamcity[buildStatisticValue key='ReceiveThroughputSagas' value='{0}']", Math.Round(throughput));
 
-            PrintStats("NumberOfRetries", NumberOfRetries, "#");
-            PrintStats("TimeToFirstMessage", (First - StartTime).Value.TotalSeconds, "s");
+                PrintStats("NumberOfRetries", NumberOfRetries, "#");
+                PrintStats("TimeToFirstMessage", (First - StartTime).Value.TotalSeconds, "s");
+            }
+
 
             if (SendTimeNoTx != TimeSpan.Zero)
                 PrintStats("Sending", Convert.ToDouble(NumberOfMessages / 2) / SendTimeNoTx.TotalSeconds, "msg/s");
 
             if (SendTimeWithTx != TimeSpan.Zero)
                 PrintStats("SendingInsideTX", Convert.ToDouble(NumberOfMessages / 2) / SendTimeWithTx.TotalSeconds, "msg/s");
+
+            if (PublishTimeNoTx != TimeSpan.Zero)
+                PrintStats("PublishTimeNoTx", Convert.ToDouble(NumberOfMessages / 2) / PublishTimeNoTx.TotalSeconds, "msg/s");
+
+            if (PublishTimeWithTx != TimeSpan.Zero)
+                PrintStats("PublishTimeWithTx", Convert.ToDouble(NumberOfMessages / 2) / PublishTimeWithTx.TotalSeconds, "msg/s");
         }
 
         static void PrintStats(string key, double value, string unit)

--- a/src/NServiceBus.NHibernate.PerformanceTests/TestEvent.cs
+++ b/src/NServiceBus.NHibernate.PerformanceTests/TestEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace Runner
+{
+    using NServiceBus;
+
+    public interface TestEvent : IEvent
+    {
+    }
+}

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -106,6 +106,7 @@
     <Compile Include="SagaPersisters\Config\Installer\Installer.cs" />
     <Compile Include="SagaPersisters\Config\Internal\SessionFactoryBuilder.cs" />
     <Compile Include="SagaPersisters\SagaPersister.cs" />
+    <Compile Include="Subscriptions\CachedSubscriptionStorage.cs" />
     <Compile Include="TimeoutPersisters\Config\TimeoutEntityMap.cs" />
     <Compile Include="TimeoutPersisters\Installer\Installer.cs" />
     <Compile Include="TimeoutPersisters\Installer\OptimizedSchemaUpdate.cs" />

--- a/src/NServiceBus.NHibernate/Subscriptions/CachedSubscriptionStorage.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/CachedSubscriptionStorage.cs
@@ -1,0 +1,54 @@
+namespace NServiceBus.Unicast.Subscriptions.NHibernate
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class CachedSubscriptionStorage : SubscriptionStorage
+    {
+        TimeSpan _expiration;
+
+        public CachedSubscriptionStorage(ISubscriptionStorageSessionProvider subscriptionStorageSessionProvider, TimeSpan expiration) : base(subscriptionStorageSessionProvider)
+        {
+            _expiration = expiration;
+        }
+
+        public override void Subscribe(Address address, IEnumerable<MessageType> messageTypes)
+        {
+            base.Subscribe(address, messageTypes);
+            _cache.Clear();
+        }
+
+        public override void Unsubscribe(Address address, IEnumerable<MessageType> messageTypes)
+        {
+            base.Unsubscribe(address, messageTypes);
+            _cache.Clear();
+        }
+
+        public override IEnumerable<Address> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes)
+        {
+            var types = messageTypes.ToList();
+            
+            var typeNames = types.Select(mt => mt.TypeName).ToArray();
+
+            var key = String.Join(",", typeNames);
+
+            Tuple<DateTimeOffset, IEnumerable<Address>> cacheItem;
+            var cacheItemFound = _cache.TryGetValue(key, out cacheItem);
+            if (cacheItemFound && (DateTimeOffset.UtcNow - cacheItem.Item1) < _expiration)
+                return cacheItem.Item2;
+
+            cacheItem = new Tuple<DateTimeOffset, IEnumerable<Address>>(
+                DateTimeOffset.UtcNow,
+                base.GetSubscriberAddressesForMessage(types)
+                );
+
+            _cache.AddOrUpdate(key, s => cacheItem, (s, tuple) => cacheItem);
+
+            return cacheItem.Item2;
+        }
+
+        static readonly ConcurrentDictionary<string, Tuple<DateTimeOffset, IEnumerable<Address>>> _cache = new ConcurrentDictionary<string, Tuple<DateTimeOffset, IEnumerable<Address>>>();
+    }
+}

--- a/src/NServiceBus.NHibernate/Subscriptions/SubscriptionStorage.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/SubscriptionStorage.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
             this.subscriptionStorageSessionProvider = subscriptionStorageSessionProvider;
         }
 
-        void ISubscriptionStorage.Subscribe(Address address, IEnumerable<MessageType> messageTypes)
+        public virtual void Subscribe(Address address, IEnumerable<MessageType> messageTypes)
         {
             using (var transaction = new TransactionScope(TransactionScopeOption.Suppress))
             using (var session = subscriptionStorageSessionProvider.OpenSession())
@@ -38,12 +38,12 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
                     }
 
                     session.Save(new Subscription
-                                        {
-                                            SubscriberEndpoint = address.ToString(),
-                                            MessageType = messageType.TypeName + "," + messageType.Version,
-                                            Version = messageType.Version.ToString(),
-                                            TypeName = messageType.TypeName
-                                        });
+                    {
+                        SubscriberEndpoint = address.ToString(),
+                        MessageType = messageType.TypeName + "," + messageType.Version,
+                        Version = messageType.Version.ToString(),
+                        TypeName = messageType.TypeName
+                    });
                 }
 
                 tx.Commit();
@@ -51,11 +51,11 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
             }
         }
 
-        void ISubscriptionStorage.Unsubscribe(Address address, IEnumerable<MessageType> messageTypes)
+        public virtual void Unsubscribe(Address address, IEnumerable<MessageType> messageTypes)
         {
             using (var transaction = new TransactionScope(TransactionScopeOption.Suppress))
             using (var session = subscriptionStorageSessionProvider.OpenSession())
-            using (var tx = session.BeginTransaction(System.Data.IsolationLevel.ReadCommitted))            
+            using (var tx = session.BeginTransaction(System.Data.IsolationLevel.ReadCommitted))
             {
                 var subscriptions = session.QueryOver<Subscription>()
                     .Where(
@@ -73,7 +73,7 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
             }
         }
 
-        IEnumerable<Address> ISubscriptionStorage.GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes)
+        public virtual IEnumerable<Address> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes)
         {
             using (var transaction = new TransactionScope(TransactionScopeOption.Suppress))
             using (var session = subscriptionStorageSessionProvider.OpenStatelessSession())


### PR DESCRIPTION
Every time you publish a message, it will query the subscription storage for endpoints to send to. This will generate a lot of sql queries in a high throughput scenario. Considering that subscriptions rarely change (only when you install/uninstall endpoints), quering the subscription storage for every message does not make much sense, IMHO.

I've implemented a very simple cache mechanism that optionally will cache these subscriptions for a configured amount of time. Setting expiration time to just 1 second can make quite a big performance boost if you have a lot of messages.

I made some very basic performance test:

No cache:
NumberOfMessages: 5000,0 (#)
PublishTimeNoTx: 2933,5 (msg/s)
PublishTimeWithTx: 4427,8 (msg/s)

Cache set to 1 second:
NumberOfMessages: 5000,0 (#)
PublishTimeNoTx: 6083,3 (msg/s)
PublishTimeWithTx: 22741,5 (msg/s)

To enable caching:

``` c#
Configure.UseNHibernateSubscriptionPersister(TimeSpan.FromSeconds(10));
```
