### PR TITLE
cleanupTimer should be disposed, making OutboxTask disposable

### DIFF
--- a/src/NServiceBus.NHibernate/Outbox/NHibernateOutboxStorage.cs
+++ b/src/NServiceBus.NHibernate/Outbox/NHibernateOutboxStorage.cs
@@ -41,7 +41,7 @@ namespace NServiceBus.Features
             config.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities());
         }
 
-        class OutboxCleaner:FeatureStartupTask
+        class OutboxCleaner:FeatureStartupTask, IDisposable
         {
             public OutboxPersister OutboxPersister { get; set; }
  
@@ -85,6 +85,8 @@ namespace NServiceBus.Features
                     cleanupTimer.Dispose(waitHandle);
 
                     waitHandle.WaitOne();
+
+                    cleanupTimer = null;
                 }
             }
 
@@ -92,10 +94,14 @@ namespace NServiceBus.Features
             {
                 OutboxPersister.RemoveEntriesOlderThan(DateTime.UtcNow - timeToKeepDeduplicationData);
             }
+
+            public void Dispose()
+            {
+                if (cleanupTimer != null)
+                    cleanupTimer.Dispose();
+            }
  
-// ReSharper disable NotAccessedField.Local
             Timer cleanupTimer;
-// ReSharper restore NotAccessedField.Local
             TimeSpan timeToKeepDeduplicationData;
             TimeSpan frequencyToRunDeduplicationDataCleanup;
         }


### PR DESCRIPTION
Following up on comments in https://github.com/Particular/NServiceBus.RavenDB/pull/43, porting relevant changes to NSB.NHibernate as well