### PR TITLE
implement IPersistTimeoutsV2 interface

### DIFF
--- a/packaging/nuget/nservicebus.nhibernate.nuspec
+++ b/packaging/nuget/nservicebus.nhibernate.nuspec
@@ -17,8 +17,8 @@
     <dependencies>
       <dependency id="Iesi.Collections" version="[3.3.3.4000, 4.0.0.0)" />
       <dependency id="NHibernate" version="[3.3.3.4001, 4.0.0.0)" />
-      <dependency id="NServiceBus" version="[4.4.2.0, 5.0.0.0)" />
-      <dependency id="NServiceBus.Interfaces" version="[4.4.2.0, 5.0.0.0)" />
+      <dependency id="NServiceBus" version="[4.4.8.0, 5.0.0.0)" />
+      <dependency id="NServiceBus.Interfaces" version="[4.4.8.0, 5.0.0.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using NServiceBus.Unicast.Subscriptions.NHibernate;
     using ObjectBuilder.Common;
     using ObjectBuilder.Common.Config;
     using Persistence.InMemory.SagaPersister;
@@ -143,6 +144,12 @@
             if (persister.Contains(typeof(MsmqSubscriptionStorage).FullName))
             {
                 return config.MsmqSubscriptionStorage();
+            }
+
+            if (persister.Contains("NServiceBus.Unicast.Subscriptions.NHibernate.CachedSubscriptionStorage")
+                || persister.Contains(typeof(SubscriptionStorage).FullName))
+            {
+                return config.UseNHibernateSubscriptionPersister();
             }
 
             CallConfigureForPersister(config, persister);

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -47,7 +47,6 @@
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=4.4.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -55,7 +54,6 @@
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
@@ -46,16 +46,16 @@
       <HintPath>..\packages\NHibernate.3.3.3.4001\lib\Net35\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.Interfaces.4.4.2\lib\net40\NServiceBus.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=4.4.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.4.4.2\lib\net40\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.4.4.2\lib\net40\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/packages.config
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/packages.config
@@ -3,8 +3,8 @@
   <package id="Iesi.Collections" version="3.4.0.4000" targetFramework="net40" />
   <package id="log4net" version="1.2.10" targetFramework="net40" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net40" />
-  <package id="NServiceBus" version="4.4.2" targetFramework="net40" />
+  <package id="NServiceBus" version="4.4.8" targetFramework="net40" />
   <package id="NServiceBus.AcceptanceTesting" version="4.4.2" targetFramework="net40" />
-  <package id="NServiceBus.Interfaces" version="4.4.2" targetFramework="net40" />
+  <package id="NServiceBus.Interfaces" version="4.4.8" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>

--- a/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/BasicMessaging/When_using_a_message_with_TimeToBeReceived_has_expired.cs
@@ -54,7 +54,7 @@
         }
 
         [Serializable]
-        [TimeToBeReceived("00:00:01")]
+        [TimeToBeReceived("00:00:000001")]
         public class MyMessage : IMessage
         {
         }

--- a/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using NServiceBus.Unicast.Subscriptions.NHibernate;
     using ObjectBuilder.Common;
     using ObjectBuilder.Common.Config;
     using Persistence.InMemory.SagaPersister;
@@ -143,6 +144,12 @@
             if (persister.Contains(typeof(MsmqSubscriptionStorage).FullName))
             {
                 return config.MsmqSubscriptionStorage();
+            }
+
+            if (persister.Contains("NServiceBus.Unicast.Subscriptions.NHibernate.CachedSubscriptionStorage") 
+                || persister.Contains(typeof(SubscriptionStorage).FullName))
+            {
+                return config.UseNHibernateSubscriptionPersister();
             }
 
             CallConfigureForPersister(config, persister);

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -44,16 +44,16 @@
       <HintPath>..\packages\NHibernate.3.3.3.4001\lib\Net35\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.Interfaces.4.4.2\lib\net40\NServiceBus.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=4.4.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.4.4.2\lib\net40\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.4.4.2\lib\net40\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -145,7 +145,7 @@
     <Compile Include="App_Packages\NServiceBus.AcceptanceTests\Transactions\When_receiving_a_message_with_transactions_disabled.cs" />
     <Compile Include="App_Packages\NServiceBus.AcceptanceTests\Transactions\When_sending_a_message_from_a_non_transactional_endpoint_with_a_ambient_transaction_enabled.cs" />
     <Compile Include="App_Packages\NServiceBus.AcceptanceTests\Transactions\When_sending_messages_within_an_ambient_transaction.cs" />
-    <Compile Include="App_Packages\NServiceBus.AcceptanceTests\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="App_Packages\NServiceBus.AcceptanceTests\Versioning\When_publishing_multiversioned_message.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="Issue_67.cs" />
     <Compile Include="When_saga_contains_nested_collection_without_parent_relation.cs" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -45,7 +45,6 @@
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=4.4.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -53,7 +52,6 @@
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate.AcceptanceTests/packages.config
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/packages.config
@@ -3,8 +3,8 @@
   <package id="Iesi.Collections" version="3.4.0.4000" targetFramework="net40" />
   <package id="log4net" version="1.2.10" targetFramework="net40" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net40" />
-  <package id="NServiceBus" version="4.4.2" targetFramework="net40" />
+  <package id="NServiceBus" version="4.4.8" targetFramework="net40" />
   <package id="NServiceBus.AcceptanceTesting" version="4.4.2" targetFramework="net40" />
-  <package id="NServiceBus.Interfaces" version="4.4.2" targetFramework="net40" />
+  <package id="NServiceBus.Interfaces" version="4.4.8" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>

--- a/src/NServiceBus.NHibernate.PerformanceTests/NServiceBus.NHibernate.PerformanceTests.csproj
+++ b/src/NServiceBus.NHibernate.PerformanceTests/NServiceBus.NHibernate.PerformanceTests.csproj
@@ -43,11 +43,9 @@
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/NServiceBus.NHibernate.PerformanceTests/NServiceBus.NHibernate.PerformanceTests.csproj
+++ b/src/NServiceBus.NHibernate.PerformanceTests/NServiceBus.NHibernate.PerformanceTests.csproj
@@ -42,12 +42,12 @@
       <HintPath>..\packages\NHibernate.3.3.3.4001\lib\Net35\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.Interfaces.4.4.2\lib\net40\NServiceBus.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.4.4.2\lib\net40\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/NServiceBus.NHibernate.PerformanceTests/packages.config
+++ b/src/NServiceBus.NHibernate.PerformanceTests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Iesi.Collections" version="3.4.0.4000" targetFramework="net40" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net40" />
-  <package id="NServiceBus" version="4.4.2" targetFramework="net40" />
-  <package id="NServiceBus.Interfaces" version="4.4.2" targetFramework="net40" />
+  <package id="NServiceBus" version="4.4.8" targetFramework="net40" />
+  <package id="NServiceBus.Interfaces" version="4.4.8" targetFramework="net40" />
 </packages>

--- a/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
+++ b/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
@@ -42,11 +42,9 @@
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
+++ b/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
@@ -41,12 +41,12 @@
       <HintPath>..\packages\NHibernate.3.3.3.4001\lib\Net35\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.Interfaces.4.4.2\lib\net40\NServiceBus.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.4.4.2\lib\net40\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_fetching_timeouts_from_storage.cs
+++ b/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_fetching_timeouts_from_storage.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
     public class When_fetching_timeouts_from_storage : InMemoryDBFixture
     {
         [Test]
-        public void Should_return_the_complete_list_of_timeouts()
+        public void GetNextChunk_should_return_the_complete_list_of_timeouts()
         {
             const int numberOfTimeoutsToAdd = 10;
 
@@ -33,7 +33,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
         }
 
         [Test]
-        public void Should_return_the_next_time_of_retrieval()
+        public void GetNextChunk_should_return_the_next_time_of_retrieval()
         {
             var nextTime = DateTime.UtcNow.AddHours(1);
 
@@ -54,6 +54,53 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
             persister.GetNextChunk(DateTime.UtcNow.AddYears(-3), out nextTimeToRunQuery);
 
             Assert.IsTrue((nextTime - nextTimeToRunQuery).TotalSeconds < 1);
+        }
+
+        [Test]
+        public void Peek_should_return_timeout_with_id()
+        {
+            var timeoutData = new TimeoutData
+            {
+                Time = DateTime.UtcNow.AddHours(-1),
+                CorrelationId = "boo",
+                Destination = new Address("timeouts", RuntimeEnvironment.MachineName),
+                SagaId = Guid.NewGuid(),
+                State = new byte[] { 0, 0, 133 },
+                Headers = new Dictionary<string, string> { { "Bar", "34234" }, { "Foo", "aString1" }, { "Super", "aString2" } },
+                OwningTimeoutManager = Configure.EndpointName,
+            };
+            persister.Add(timeoutData);
+
+            var result = persister.Peek(timeoutData.Id);
+
+            Assert.AreEqual(timeoutData.Id, result.Id);
+            Assert.AreEqual(timeoutData.Time.ToString("G"), result.Time.ToString("G"));
+            Assert.AreEqual(timeoutData.CorrelationId, result.CorrelationId);
+            Assert.AreEqual(timeoutData.Destination, result.Destination);
+            Assert.AreEqual(timeoutData.SagaId, result.SagaId);
+            Assert.AreEqual(timeoutData.State, result.State);
+            Assert.AreEqual(timeoutData.Headers, result.Headers);
+            Assert.AreEqual(timeoutData.OwningTimeoutManager, result.OwningTimeoutManager);
+        }
+
+        [Test]
+        public void Peek_should_return_null_when_no_existing_timeout_with_id()
+        {
+            var timeoutData = new TimeoutData
+            {
+                Time = DateTime.UtcNow.AddHours(-1),
+                CorrelationId = "boo",
+                Destination = new Address("timeouts", RuntimeEnvironment.MachineName),
+                SagaId = Guid.NewGuid(),
+                State = new byte[] { 0, 0, 133 },
+                Headers = new Dictionary<string, string> { { "Bar", "34234" }, { "Foo", "aString1" }, { "Super", "aString2" } },
+                OwningTimeoutManager = Configure.EndpointName,
+            };
+            persister.Add(timeoutData);
+
+            var result = persister.Peek(Guid.NewGuid().ToString());
+
+            Assert.IsNull(result);
         }
     }
 }

--- a/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_fetching_timeouts_from_storage.cs
+++ b/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_fetching_timeouts_from_storage.cs
@@ -80,7 +80,6 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
             Assert.AreEqual(timeoutData.SagaId, result.SagaId);
             Assert.AreEqual(timeoutData.State, result.State);
             Assert.AreEqual(timeoutData.Headers, result.Headers);
-            Assert.AreEqual(timeoutData.OwningTimeoutManager, result.OwningTimeoutManager);
         }
 
         [Test]

--- a/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_removing_timeouts_from_the_storage.cs
@@ -2,6 +2,8 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Transactions;
     using NUnit.Framework;
     using Support;
     using Timeout.Core;
@@ -10,7 +12,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
     public class When_removing_timeouts_from_the_storage : InMemoryDBFixture
     {
         [Test]
-        public void Should_return_the_correct_headers()
+        public void TryRemove_should_return_the_correct_headers()
         {
             var headers = new Dictionary<string, string>
                           {
@@ -38,7 +40,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
         }
 
         [Test]
-        public void Should_remove_timeouts_by_id()
+        public void TryRemove_should_remove_timeouts_by_id()
         {
             var t1 = new TimeoutData
                      {
@@ -79,7 +81,63 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
         }
 
         [Test]
-        public void Should_remove_timeouts_by_sagaid()
+        public void TryRemove_should_return_false_when_timeout_already_deleted()
+        {
+            var timeout = new TimeoutData();
+
+            persister.Add(timeout);
+
+            Assert.IsTrue(persister.TryRemove(timeout.Id));
+            Assert.IsFalse(persister.TryRemove(timeout.Id));
+        }
+
+        [Test]
+        public void TryRemove_should_work_with_concurrent_transactions()
+        {
+            var timeout = new TimeoutData();
+
+            persister.Add(timeout);
+
+            var t1EnteredTx = new AutoResetEvent(false);
+            var t2EnteredTx = new AutoResetEvent(false);
+            bool? t1Result = null;
+            bool? t2Result = null;
+
+            var t1 = new Thread(() =>
+            {
+                using (var tx = new TransactionScope())
+                {
+                    t1EnteredTx.Set();
+                    t2EnteredTx.WaitOne();
+                    t1Result = persister.TryRemove(timeout.Id);
+                    tx.Complete();
+                }
+            });
+            var t2 = new Thread(() =>
+            {
+                using (var tx = new TransactionScope())
+                {
+                    t2EnteredTx.Set();
+                    t1EnteredTx.WaitOne();
+                    t2Result = persister.TryRemove(timeout.Id);
+                    tx.Complete();
+                }
+            });
+
+            t1.Start();
+            t2.Start();
+            t1.Join(TimeSpan.FromSeconds(10));
+            t2.Join(TimeSpan.FromSeconds(10));
+
+            Assert.IsTrue(t1Result.HasValue && t2Result.HasValue);
+
+            // one delete should succeed, the other one shouldn't
+            Assert.IsTrue(t1Result.Value || t2Result.Value);
+            Assert.IsFalse(t1Result.Value && t2Result.Value);
+        }
+
+        [Test]
+        public void RemiveTimeoutBy_should_remove_timeouts_by_sagaid()
         {
             var sagaId1 = Guid.NewGuid();
             var sagaId2 = Guid.NewGuid();

--- a/src/NServiceBus.NHibernate.Tests/packages.config
+++ b/src/NServiceBus.NHibernate.Tests/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Iesi.Collections" version="3.4.0.4000" targetFramework="net40" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net40" />
-  <package id="NServiceBus" version="4.4.2" targetFramework="net40" />
-  <package id="NServiceBus.Interfaces" version="4.4.2" targetFramework="net40" />
+  <package id="NServiceBus" version="4.4.8" targetFramework="net40" />
+  <package id="NServiceBus.Interfaces" version="4.4.8" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
   <package id="System.Data.SQLite.x64" version="1.0.87.0" targetFramework="net40" />
 </packages>

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -13,7 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <NuGetPackageImportStamp>f3fcc13a</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -131,15 +132,15 @@
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.1.25.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.25.0\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.25.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.25.0\build\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.1.3.3\Build\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.1.3.3\Build\GitVersionTask.targets'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.1.3.3\Build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.1.3.3\Build\GitVersionTask.targets')" />
   <Import Project="..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.4.13\build\NuGetPackager.targets')" />
+  <Import Project="..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
 </Project>

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -55,12 +55,12 @@
       <HintPath>..\packages\NHibernate.3.3.3.4001\lib\Net35\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.Interfaces.4.4.2\lib\net40\NServiceBus.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NServiceBus.4.4.2\lib\net40\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Obsolete, Version=3.1.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -56,11 +56,9 @@
     </Reference>
     <Reference Include="NServiceBus, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Interfaces.4.4.8\lib\net40\NServiceBus.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.4.4.8\lib\net40\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Obsolete, Version=3.1.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NServiceBus.NHibernate/Persistence/ConfigureNHibernate.cs
+++ b/src/NServiceBus.NHibernate/Persistence/ConfigureNHibernate.cs
@@ -245,6 +245,7 @@ PM> Install-Package System.Data.SQLite.{1}
                 return new Dictionary<string, string>(properties);
             }
 
+            // ReSharper disable once UseObjectOrCollectionInitializer
             var overriddenProperties = new Dictionary<string, string>(properties);
             overriddenProperties[Environment.ConnectionString] = connectionStringOverride;
 

--- a/src/NServiceBus.NHibernate/packages.config
+++ b/src/NServiceBus.NHibernate/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="1.25.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Fody" version="1.29.3" targetFramework="net4" developmentDependency="true" />
   <package id="GitVersionTask" version="1.3.3" targetFramework="net40" developmentDependency="true" />
   <package id="Iesi.Collections" version="3.4.0.4000" targetFramework="net40" />
   <package id="Janitor.Fody" version="1.1.0.0" targetFramework="net40" />

--- a/src/NServiceBus.NHibernate/packages.config
+++ b/src/NServiceBus.NHibernate/packages.config
@@ -5,8 +5,8 @@
   <package id="Iesi.Collections" version="3.4.0.4000" targetFramework="net40" />
   <package id="Janitor.Fody" version="1.1.0.0" targetFramework="net40" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net40" />
-  <package id="NServiceBus" version="4.4.2" targetFramework="net40" />
-  <package id="NServiceBus.Interfaces" version="4.4.2" targetFramework="net40" />
+  <package id="NServiceBus" version="4.4.8" targetFramework="net40" />
+  <package id="NServiceBus.Interfaces" version="4.4.8" targetFramework="net40" />
   <package id="NuGetPackager" version="0.4.13" targetFramework="net40" developmentDependency="true" />
   <package id="Obsolete.Fody" version="3.1.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Implement the IPersistTimeoutsV2 interface in order to fix loosing timeout messages when not using dtc.

see issue https://github.com/Particular/NServiceBus/issues/2885

Connects to Particular/NServiceBus#2885