### PR TITLE
Fixed handling of transactions in Add and TryRemove methods

### DIFF
--- a/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0-unstable1509/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.0.0-unstable1509/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -44,10 +44,12 @@
                 public Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     Context.FinderUsed = true;
-                    return Task.FromResult(new TestSaga08.SagaData08
+                    var sagaData = new TestSaga08.SagaData08
                     {
                         Property = "jfbsjdfbsdjh"
-                    });
+                    };
+                    storageSession.Session().Save(sagaData);
+                    return Task.FromResult(sagaData);
                 }
             }
 

--- a/src/NServiceBus.NHibernate.AcceptanceTests/When_saga_contains_nested_collection_with_row_version.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/When_saga_contains_nested_collection_with_row_version.cs
@@ -63,9 +63,9 @@
                     if (Data.RelatedData == null)
                     Data.RelatedData = new List<ChildData>
                                        {
-                                           new ChildData{Parent = Data},
-                                           new ChildData{Parent = Data},
-                                           new ChildData{Parent = Data}
+                                           new ChildData{NHNestedColRowVerSagaData = Data},
+                                           new ChildData{NHNestedColRowVerSagaData = Data},
+                                           new ChildData{NHNestedColRowVerSagaData = Data}
                                        };
                     if (Data.MessageOneReceived && Data.MessageTwoReceived && Data.MessageThreeReceived)
                     {
@@ -144,7 +144,7 @@
         public class ChildData
         {
             public virtual Guid Id { get; set; }
-            public virtual NHNestedColRowVerSagaData Parent { get; set; }
+            public virtual NHNestedColRowVerSagaData NHNestedColRowVerSagaData { get; set; }
         }
         [Serializable]
         public class SagaCompleted : IMessage

--- a/src/NServiceBus.NHibernate.Tests/TimeoutPersister/InMemoryDBFixture.cs
+++ b/src/NServiceBus.NHibernate.Tests/TimeoutPersister/InMemoryDBFixture.cs
@@ -6,15 +6,21 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
     using global::NHibernate;
     using global::NHibernate.Mapping.ByCode;
     using global::NHibernate.Tool.hbm2ddl;
+    using NServiceBus.Persistence.NHibernate;
     using NUnit.Framework;
 
     abstract class InMemoryDBFixture
     {
+#if USE_SQLSERVER
+        private readonly string connectionString = @"Data Source=.\SQLEXPRESS;Initial Catalog=nservicebus;Integrated Security=True;";
+        private const string dialect = "NHibernate.Dialect.MsSql2012Dialect";
+#else
+        readonly string connectionString = $@"Data Source={Path.GetTempFileName()};Version=3;New=True;";
+        const string dialect = "NHibernate.Dialect.SQLiteDialect";
+#endif
+
         protected TimeoutPersister persister;
         protected ISessionFactory sessionFactory;
-
-        string connectionString = $@"Data Source={Path.GetTempFileName()};Version=3;New=True;";
-        const string dialect = "NHibernate.Dialect.SQLiteDialect";
 
         [SetUp]
         public void Setup()
@@ -34,7 +40,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
 
             sessionFactory = configuration.BuildSessionFactory();
 
-            persister = new TimeoutPersister("MyTestEndpoint", sessionFactory);
+            persister = new TimeoutPersister("MyTestEndpoint", sessionFactory, new NHibernateSynchronizedStorageAdapter(sessionFactory), new NHibernateSynchronizedStorage(sessionFactory));
         }
     }
 }

--- a/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.NHibernate.Tests/TimeoutPersister/When_removing_timeouts_from_the_storage.cs
@@ -2,10 +2,14 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Data.SqlClient;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Transactions;
+    using global::NHibernate.Impl;
     using NServiceBus.Extensibility;
+    using NServiceBus.Transports;
     using NUnit.Framework;
     using Timeout.Core;
 
@@ -53,9 +57,95 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
         }
 
         [Test]
+        public async Task When_in_transaction_scope_add_should_not_commit_until_scope_is_complete()
+        {
+            var data = new TimeoutData
+            {
+                Time = DateTime.Now.AddYears(-1),
+                OwningTimeoutManager = "MyTestEndpoint",
+            };
+
+            var contextBag = new ContextBag();
+
+            using (new TransactionScope())
+            {
+                var transaction = new TransportTransaction();
+                transaction.Set(Transaction.Current);
+                contextBag.Set(transaction);
+                await persister.Add(data, contextBag).ConfigureAwait(false);
+            }
+
+            using (var session = sessionFactory.OpenSession())
+            {
+                Assert.Null(session.Get<TimeoutEntity>(new Guid(data.Id)));
+            }
+        }
+
+        [Test][Explicit("SQL Server specific")]
+        public async Task When_in_transaction_scope_with_sql_connection_should_hook_up_to_that_connection()
+        {
+            var data = new TimeoutData
+            {
+                Time = DateTime.Now,
+                OwningTimeoutManager = "MyTestEndpoint",
+            };
+
+            var contextBag = new ContextBag();
+
+            using (var tx = new TransactionScope())
+            {
+                var connection = (SqlConnection) ((SessionFactoryImpl) sessionFactory).ConnectionProvider.GetConnection();
+
+                var transaction = new TransportTransaction();
+                transaction.Set(Transaction.Current);
+                transaction.Set(connection);
+                contextBag.Set(transaction);
+                await persister.Add(data, contextBag).ConfigureAwait(false);
+
+                Assert.AreEqual(Guid.Empty, Transaction.Current.TransactionInformation.DistributedIdentifier);
+
+                tx.Complete();
+            }
+
+            using (var session = sessionFactory.OpenSession())
+            {
+                Assert.NotNull(session.Get<TimeoutEntity>(new Guid(data.Id)));
+            }
+        }
+
+        [Test]
+        public async Task When_in_transaction_scope_add_should_commit_when_scope_is_complete()
+        {
+            var data = new TimeoutData
+            {
+                Time = DateTime.Now.AddYears(-1),
+                OwningTimeoutManager = "MyTestEndpoint",
+            };
+
+            var contextBag = new ContextBag();
+
+            using (var tx = new TransactionScope())
+            {
+                var transaction = new TransportTransaction();
+                transaction.Set(Transaction.Current);
+                contextBag.Set(transaction);
+                await persister.Add(data, contextBag).ConfigureAwait(false);
+                tx.Complete();
+            }
+
+            using (var session = sessionFactory.OpenSession())
+            {
+                Assert.NotNull(session.Get<TimeoutEntity>(new Guid(data.Id)));
+            }
+        }
+
+        [Test]
         public async Task TryRemove_should_return_false_when_timeout_already_deleted()
         {
-            var timeout = new TimeoutData();
+            var timeout = new TimeoutData()
+            {
+                Time = DateTime.Now
+            };
 
             await persister.Add(timeout, new ContextBag()).ConfigureAwait(false);
 
@@ -66,7 +156,10 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Tests
         [Test]
         public async Task Peek_should_return_no_timeout_when_timeout_already_deleted()
         {
-            var timeout = new TimeoutData();
+            var timeout = new TimeoutData()
+            {
+                Time = DateTime.Now
+            };
 
             await persister.Add(timeout, new ContextBag()).ConfigureAwait(false);
 

--- a/src/NServiceBus.NHibernate/TimeoutPersisters/NHibernateTimeoutStorage.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/NHibernateTimeoutStorage.cs
@@ -41,7 +41,14 @@ namespace NServiceBus.Features
             }
 
             context.Container.ConfigureComponent(b => new Installer.SchemaUpdater(installAction), DependencyLifecycle.SingleInstance);
-            context.Container.ConfigureComponent(b => new TimeoutPersister(context.Settings.EndpointName().ToString(), config.Configuration.BuildSessionFactory()), DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent(b =>
+            {
+                var sessionFactory = config.Configuration.BuildSessionFactory();
+                return new TimeoutPersister(
+                    context.Settings.EndpointName().ToString(),
+                    sessionFactory,
+                    new NHibernateSynchronizedStorageAdapter(sessionFactory), new NHibernateSynchronizedStorage(sessionFactory));
+            }, DependencyLifecycle.SingleInstance);
         }
 
         static bool RunInstaller(FeatureConfigurationContext context)


### PR DESCRIPTION
Replacement for #154 

General idea: in V5 the methods on `TimeoutPersister`  had some fancy clever code that would hook up to an existing `SqlConnection` or `TransactionScope`. In V6 I dropped them in favor of just opening a new session each time within a suppressing scope. That change broke *exactly-once* configuration where the correctness depends on being able to have atomic receive and storage operation. This pull attempts to correct this mistake by re-using the synchronized storage adapter which already implements the mentioned "fancy clever code". 