### PR TITLE
Marking custom session initialization and access obsolete.

### DIFF
--- a/src/NServiceBus.NHibernate/Obsoletes/NHibernateStorageContext.cs
+++ b/src/NServiceBus.NHibernate/Obsoletes/NHibernateStorageContext.cs
@@ -7,7 +7,10 @@ namespace NServiceBus.Persistence.NHibernate
     /// <summary>
     /// Provides users with access to the current NHibernate <see cref="ITransaction"/>, <see cref="IDbConnection"/> and <see cref="ISession"/>. 
     /// </summary>
-    [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", ReplacementTypeOrMember = "IMessageHandlingContext.StorageSession")]
+    [ObsoleteEx(
+        RemoveInVersion = "8", 
+        TreatAsErrorFromVersion = "7", 
+        ReplacementTypeOrMember = "IMessageHandlingContext.StorageSession")]
     public class NHibernateStorageContext
     {
         /// <summary>

--- a/src/NServiceBus.NHibernate/SharedConfig.cs
+++ b/src/NServiceBus.NHibernate/SharedConfig.cs
@@ -47,7 +47,10 @@
         /// </summary>
         /// <param name="persistenceConfiguration"></param>
         /// <returns></returns>
-        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", ReplacementTypeOrMember = "IMessageHandlerContext.SynchronizedStorageSession.Session")]
+        [ObsoleteEx(
+            RemoveInVersion = "8", 
+            TreatAsErrorFromVersion = "7", 
+            ReplacementTypeOrMember = "IMessageHandlerContext.SynchronizedStorageSession.Session")]
         public static PersistenceExtentions<NHibernatePersistence> RegisterManagedSessionInTheContainer(this PersistenceExtentions<NHibernatePersistence> persistenceConfiguration)
         {
             throw new NotImplementedException();
@@ -59,7 +62,10 @@
         /// <param name="persistenceConfiguration"></param>
         /// <param name="callback"></param>
         /// <returns></returns>
-        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", Message = "Custom session creation is no longer supported. Entity mapping can be done through providing custom NHibernate Configuration object on endpoint initialization.")]
+        [ObsoleteEx(
+            RemoveInVersion = "8", 
+            TreatAsErrorFromVersion = "7", 
+            Message = "Custom session creation is no longer supported. Entity mapping can be done through providing custom NHibernate Configuration object on endpoint initialization.")]
         public static PersistenceExtentions<NHibernatePersistence> UseCustomSessionCreationMethod(this PersistenceExtentions<NHibernatePersistence> persistenceConfiguration, Func<ISessionFactory, string, ISession> callback)
         {
             throw new NotImplementedException();

--- a/src/NServiceBus.NHibernate/SharedConfig.cs
+++ b/src/NServiceBus.NHibernate/SharedConfig.cs
@@ -59,7 +59,7 @@
         /// <param name="persistenceConfiguration"></param>
         /// <param name="callback"></param>
         /// <returns></returns>
-        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", Message = "This is no longer supported. You can still provide your NHibernate Configuration object.")]
+        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", Message = "Custom session creation is no longer supported. Entity mapping can be done through providing custom NHibernate Configuration object on endpoint initialization.")]
         public static PersistenceExtentions<NHibernatePersistence> UseCustomSessionCreationMethod(this PersistenceExtentions<NHibernatePersistence> persistenceConfiguration, Func<ISessionFactory, string, ISession> callback)
         {
             throw new NotImplementedException();

--- a/src/NServiceBus.NHibernate/SharedConfig.cs
+++ b/src/NServiceBus.NHibernate/SharedConfig.cs
@@ -50,7 +50,7 @@
         [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", ReplacementTypeOrMember = "IMessageHandlerContext.SynchronizedStorageSession.Session")]
         public static PersistenceExtentions<NHibernatePersistence> RegisterManagedSessionInTheContainer(this PersistenceExtentions<NHibernatePersistence> persistenceConfiguration)
         {
-            return persistenceConfiguration;
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -62,7 +62,7 @@
         [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", Message = "This is no longer supported. You can still provide your NHibernate Configuration object.")]
         public static PersistenceExtentions<NHibernatePersistence> UseCustomSessionCreationMethod(this PersistenceExtentions<NHibernatePersistence> persistenceConfiguration, Func<ISessionFactory, string, ISession> callback)
         {
-            return persistenceConfiguration;
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/NServiceBus.NHibernate/SharedConfig.cs
+++ b/src/NServiceBus.NHibernate/SharedConfig.cs
@@ -47,9 +47,9 @@
         /// </summary>
         /// <param name="persistenceConfiguration"></param>
         /// <returns></returns>
+        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", ReplacementTypeOrMember = "IMessageHandlerContext.SynchronizedStorageSession.Session")]
         public static PersistenceExtentions<NHibernatePersistence> RegisterManagedSessionInTheContainer(this PersistenceExtentions<NHibernatePersistence> persistenceConfiguration)
         {
-            persistenceConfiguration.GetSettings().Set("NHibernate.RegisterManagedSession", true);
             return persistenceConfiguration;
         }
 
@@ -59,13 +59,9 @@
         /// <param name="persistenceConfiguration"></param>
         /// <param name="callback"></param>
         /// <returns></returns>
+        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", Message = "This is no longer supported. You can still provide your NHibernate Configuration object.")]
         public static PersistenceExtentions<NHibernatePersistence> UseCustomSessionCreationMethod(this PersistenceExtentions<NHibernatePersistence> persistenceConfiguration, Func<ISessionFactory, string, ISession> callback)
         {
-            if (callback == null)
-            {
-                throw new ArgumentNullException("callback");
-            }
-            persistenceConfiguration.GetSettings().Set("NHibernate.SessionCreator", callback);
             return persistenceConfiguration;
         }
     }


### PR DESCRIPTION
I've made two sessions that are no-op / not supported as obsolete. 