### PR TITLE
Added a storage session class that enables testing of NH handlers

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/SagaPersister/When_persisting_a_saga_with_a_unique_property.cs
+++ b/src/NServiceBus.NHibernate.Tests/SagaPersister/When_persisting_a_saga_with_a_unique_property.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
-    using NServiceBus.Persistence.NHibernate;
     using NServiceBus.Sagas;
+    using NServiceBus.Testing;
     using NUnit.Framework;
 
     [TestFixture]
@@ -18,7 +18,7 @@
             using (var transaction = session.BeginTransaction())
             {
                 var correlationProperty = new SagaCorrelationProperty("UniqueString", "whatever");
-                var storageSession = new NHibernateNativeTransactionSynchronizedStorageSession(session, transaction, false);
+                var storageSession = new TestingNHibernateSynchronizedStorageSession(session);
 
                 await SagaPersister.Save(new SagaWithUniqueProperty
                 {

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Deduplication\NHibernateGatewayDeduplication.cs" />
     <Compile Include="NHibernatePersistence.cs" />
     <Compile Include="SagaPersisters\LockModes.cs" />
+    <Compile Include="SynchronizedStorage\TestingNHibernateSynchronizedStorageSession.cs" />
     <Compile Include="SynchronizedStorage\NHibernateNativeTransactionSynchronizedStorageSession.cs" />
     <Compile Include="Outbox\NHibernateOutboxTransaction.cs" />
     <Compile Include="SynchronizedStorage\NHibernateSynchronizedStorage.cs" />

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/TestingNHibernateSynchronizedStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/TestingNHibernateSynchronizedStorageSession.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.Testing
+{
+    using global::NHibernate;
+    using Janitor;
+    using NServiceBus.Persistence;
+
+    /// <summary>
+    /// Allows writing automated tests against handlers which use NServiceBus-managed NHibernate session.
+    /// </summary>
+    [SkipWeaving]
+    public class TestingNHibernateSynchronizedStorageSession: SynchronizedStorageSession, INHibernateSynchronizedStorageSession
+    {
+        /// <summary>
+        /// Creates new instance of the session.
+        /// </summary>
+        /// <param name="session">An opened NHibernate session to use in the test. The session is not automatically flushed..</param>
+        public TestingNHibernateSynchronizedStorageSession(ISession session)
+        {
+            Session = session;
+        }
+
+        /// <summary>
+        /// Gets the underlying NHibernate session.
+        /// </summary>
+        public ISession Session { get; }
+    }
+}


### PR DESCRIPTION
Connects to Particular/NServiceBus.Testing#29

This pull adds a storage session implementation that can be used only for testing handlers that uses NServiceBus-managed NHibernate session.