### PR TITLE
SchemaUpdater can be not present in setting

### DIFF
--- a/src/NServiceBus.NHibernate/Deduplication/Installer/Installer.cs
+++ b/src/NServiceBus.NHibernate/Deduplication/Installer/Installer.cs
@@ -9,7 +9,7 @@
     {
         public Installer(ReadOnlySettings settings)
         {
-            schemaUpdater = settings.Get<SchemaUpdater>();
+            settings.TryGet(out schemaUpdater);
         }
 
         public Task Install(string identity)

--- a/src/NServiceBus.NHibernate/Subscriptions/Installer/Installer.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/Installer/Installer.cs
@@ -9,11 +9,16 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate.Installer
     {
         public Installer(ReadOnlySettings settings)
         {
-            schemaUpdater = settings.Get<SchemaUpdater>();
+            settings.TryGet(out schemaUpdater);
         }
 
         public Task Install(string identity)
         {
+            if (schemaUpdater == null)
+            {
+                return Task.FromResult(0);
+            }
+
             return schemaUpdater.Execute(identity);
         }
 

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/Installer/Installer.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/Installer/Installer.cs
@@ -9,11 +9,16 @@ namespace NServiceBus.Persistence.NHibernate.Installer
     {
         public Installer(ReadOnlySettings settings)
         {
-            schemaUpdater = settings.Get<SchemaUpdater>();
+            settings.TryGet(out schemaUpdater);
         }
 
         public Task Install(string identity)
         {
+            if (schemaUpdater == null)
+            {
+                return Task.FromResult(0);
+            }
+
             return schemaUpdater.Execute(identity);
         }
 

--- a/src/NServiceBus.NHibernate/TimeoutPersisters/Installer/Installer.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/Installer/Installer.cs
@@ -9,11 +9,16 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Installer
     {
         public Installer(ReadOnlySettings settings)
         {
-            schemaUpdater = settings.Get<SchemaUpdater>();
+            settings.TryGet(out schemaUpdater);
         }
 
         public Task Install(string identity)
         {
+            if (schemaUpdater == null)
+            {
+                return Task.FromResult(0);
+            }
+
             return schemaUpdater.Execute(identity);
         }
 


### PR DESCRIPTION
@Particular/nservicebus-maintainers this fixes a bug introduced in #187

We no longer assume the defaults to be applied

cc @HEskandari

@Particular/nhibernate-persistence-maintainers please review