### PR TITLE
TimeoutsChunk uses array for timeouts and timeouts is a struct to reduce garbage

### DIFF
--- a/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
@@ -55,8 +55,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate
 
                     //Retrieve next time we need to run query
                     var startOfNextChunk = session.QueryOver<TimeoutEntity>()
-                        .Where(x => x.Endpoint == EndpointName)
-                        .Where(x => x.Time > now)
+                        .Where(x => x.Endpoint == EndpointName && x.Time > now)
                         .OrderBy(x => x.Time).Asc
                         .Take(1)
                         .SingleOrDefault();


### PR DESCRIPTION
https://github.com/Particular/NServiceBus/pull/3932