### PR TITLE
Make Outbox settings available as extension methods on .EnableOutbox()

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
+++ b/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
@@ -83,6 +83,7 @@
   <ItemGroup>
     <Compile Include="Outbox\FakeDbConnectionProvider.cs" />
     <Compile Include="Outbox\InMemoryDBFixture.cs" />
+    <Compile Include="Outbox\OutboxApiExtensions.cs" />
     <Compile Include="Outbox\When_deserializing_outbox_messages.cs" />
     <Compile Include="Outbox\When_adding_outbox_messages.cs" />
     <Compile Include="Persistence\NHibernateConfigurationBuilderTests.cs" />

--- a/src/NServiceBus.NHibernate.Tests/Outbox/OutboxApiExtensions.cs
+++ b/src/NServiceBus.NHibernate.Tests/Outbox/OutboxApiExtensions.cs
@@ -1,0 +1,35 @@
+﻿namespace NServiceBus.NHibernate.Tests.Outbox
+{
+    using System;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.NHibernate.Outbox;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OutboxApiExtensions
+    {
+        [Test]
+        public void TestSetTimeToKeepDeduplicationData()
+        {
+            var cfg = new EndpointConfiguration("Test");
+
+            var outbox = cfg.EnableOutbox();
+
+            outbox.SetTimeToKeepDeduplicationData(TimeSpan.FromMinutes(42));
+
+            Assert.AreEqual(42, cfg.GetSettings().Get<TimeSpan>("Outbox.TimeToKeepDeduplicationData").Minutes);
+        }
+
+        [Test]
+        public void SetFrequencyToRunDeduplicationDataCleanup()
+        {
+            var cfg = new EndpointConfiguration("Test");
+
+            var outbox = cfg.EnableOutbox();
+
+            outbox.SetFrequencyToRunDeduplicationDataCleanup(TimeSpan.FromMinutes(13));
+
+            Assert.AreEqual(13, cfg.GetSettings().Get<TimeSpan>("Outbox.FrequencyToRunDeduplicationDataCleanup").Minutes);
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate.Tests/Outbox/OutboxApiExtensions.cs
+++ b/src/NServiceBus.NHibernate.Tests/Outbox/OutboxApiExtensions.cs
@@ -15,19 +15,19 @@
 
             var outbox = cfg.EnableOutbox();
 
-            outbox.SetTimeToKeepDeduplicationData(TimeSpan.FromMinutes(42));
+            NHibernateOutboxExtensions.TimeToKeepDeduplicationData(outbox, TimeSpan.FromMinutes(42));
 
             Assert.AreEqual(42, cfg.GetSettings().Get<TimeSpan>("Outbox.TimeToKeepDeduplicationData").Minutes);
         }
 
         [Test]
-        public void SetFrequencyToRunDeduplicationDataCleanup()
+        public void TestFrequencyToRunDeduplicationDataCleanup()
         {
             var cfg = new EndpointConfiguration("Test");
 
             var outbox = cfg.EnableOutbox();
 
-            outbox.SetFrequencyToRunDeduplicationDataCleanup(TimeSpan.FromMinutes(13));
+            outbox.FrequencyToRunDeduplicationDataCleanup(TimeSpan.FromMinutes(13));
 
             Assert.AreEqual(13, cfg.GetSettings().Get<TimeSpan>("Outbox.FrequencyToRunDeduplicationDataCleanup").Minutes);
         }

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -84,6 +84,7 @@
   <ItemGroup>
     <Compile Include="Internal\NHibernateConfiguration.cs" />
     <Compile Include="Internal\ObjectSerializer.cs" />
+    <Compile Include="Outbox\NHibernateOutboxExtensions.cs" />
     <Compile Include="SynchronizedStorage\INHibernateSynchronizedStorageSession.cs" />
     <Compile Include="SynchronizedStorage\NHibernateAmbientTransactionSynchronizedStorageSession.cs" />
     <Compile Include="Obsoletes\NHibernateStorageContext.cs" />

--- a/src/NServiceBus.NHibernate/Outbox/NHibernateOutboxExtensions.cs
+++ b/src/NServiceBus.NHibernate/Outbox/NHibernateOutboxExtensions.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.NHibernate.Outbox
+{
+    using System;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.Outbox;
+
+    /// <summary>
+    /// Contains extensions methods which allow to configure RavenDB outbox specific configuration
+    /// </summary>
+    public static class NHibernateOutboxExtensions
+    {
+        /// <summary>
+        /// Sets the time to keep the deduplication data to the specified time span.
+        /// </summary>
+        /// <param name="configuration">The configuration being extended</param>
+        /// <param name="timeToKeepDeduplicationData">The time to keep the deduplication data. 
+        /// The cleanup process removes entries older than the specified time to keep deduplication data, therefore the time span cannot be negative</param>
+        /// <returns>The configuration</returns>
+        public static OutboxSettings SetTimeToKeepDeduplicationData(this OutboxSettings configuration, TimeSpan timeToKeepDeduplicationData)
+        {
+            var now = DateTime.UtcNow;
+            if (now - timeToKeepDeduplicationData >= now)
+            {
+                throw new ArgumentException("Specify a non-negative TimeSpan. The cleanup process removes entries older than the specified time to keep deduplication data, therefore the time span cannot be negative.", "timeToKeepDeduplicationData");
+            }
+
+            configuration.GetSettings().Set("Outbox.TimeToKeepDeduplicationData", timeToKeepDeduplicationData);
+            return configuration;
+        }
+
+        /// <summary>
+        /// Sets the frequency to run the deduplication data cleanup task.
+        /// </summary>
+        /// <param name="configuration">The configuration being extended</param>
+        /// <param name="frequencyToRunDeduplicationDataCleanup">The frequency to run the deduplication data cleanup task. By specifying a negative time span (-1) the cleanup task will never run.</param>
+        /// <returns>The configuration</returns>
+        public static OutboxSettings SetFrequencyToRunDeduplicationDataCleanup(this OutboxSettings configuration, TimeSpan frequencyToRunDeduplicationDataCleanup)
+        {
+            configuration.GetSettings().Set("Outbox.FrequencyToRunDeduplicationDataCleanup", frequencyToRunDeduplicationDataCleanup);
+            return configuration;
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate/Outbox/NHibernateOutboxExtensions.cs
+++ b/src/NServiceBus.NHibernate/Outbox/NHibernateOutboxExtensions.cs
@@ -9,6 +9,12 @@
     /// </summary>
     public static class NHibernateOutboxExtensions
     {
+        internal const string TimeToKeepDeduplicationDataSettingsKey = "Outbox.TimeToKeepDeduplicationData";
+        internal const string FrequencyToRunDeduplicationDataCleanupSettingsKey = "Outbox.FrequencyToRunDeduplicationDataCleanup";
+
+        internal const string TimeToKeepDeduplicationDataAppSetting = "NServiceBus/Outbox/NHibernate/TimeToKeepDeduplicationData";
+        internal const string FrequencyToRunDeduplicationDataCleanupAppSetting = "NServiceBus/Outbox/NHibernate/FrequencyToRunDeduplicationDataCleanup";
+
         /// <summary>
         /// Sets the time to keep the deduplication data to the specified time span.
         /// </summary>
@@ -16,15 +22,14 @@
         /// <param name="timeToKeepDeduplicationData">The time to keep the deduplication data. 
         /// The cleanup process removes entries older than the specified time to keep deduplication data, therefore the time span cannot be negative</param>
         /// <returns>The configuration</returns>
-        public static OutboxSettings SetTimeToKeepDeduplicationData(this OutboxSettings configuration, TimeSpan timeToKeepDeduplicationData)
+        public static OutboxSettings TimeToKeepDeduplicationData(this OutboxSettings configuration, TimeSpan timeToKeepDeduplicationData)
         {
-            var now = DateTime.UtcNow;
-            if (now - timeToKeepDeduplicationData >= now)
+            if (timeToKeepDeduplicationData <= TimeSpan.Zero)
             {
                 throw new ArgumentException("Specify a non-negative TimeSpan. The cleanup process removes entries older than the specified time to keep deduplication data, therefore the time span cannot be negative.", "timeToKeepDeduplicationData");
             }
 
-            configuration.GetSettings().Set("Outbox.TimeToKeepDeduplicationData", timeToKeepDeduplicationData);
+            configuration.GetSettings().Set(TimeToKeepDeduplicationDataSettingsKey, timeToKeepDeduplicationData);
             return configuration;
         }
 
@@ -34,7 +39,7 @@
         /// <param name="configuration">The configuration being extended</param>
         /// <param name="frequencyToRunDeduplicationDataCleanup">The frequency to run the deduplication data cleanup task. By specifying a negative time span (-1) the cleanup task will never run.</param>
         /// <returns>The configuration</returns>
-        public static OutboxSettings SetFrequencyToRunDeduplicationDataCleanup(this OutboxSettings configuration, TimeSpan frequencyToRunDeduplicationDataCleanup)
+        public static OutboxSettings FrequencyToRunDeduplicationDataCleanup(this OutboxSettings configuration, TimeSpan frequencyToRunDeduplicationDataCleanup)
         {
             configuration.GetSettings().Set("Outbox.FrequencyToRunDeduplicationDataCleanup", frequencyToRunDeduplicationDataCleanup);
             return configuration;

--- a/src/NServiceBus.NHibernate/Outbox/OutboxCleaner.cs
+++ b/src/NServiceBus.NHibernate/Outbox/OutboxCleaner.cs
@@ -5,14 +5,16 @@ namespace NServiceBus.Features
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Persistence.NHibernate;
+    using NServiceBus.Settings;
 
     class OutboxCleaner : FeatureStartupTask
     {
         public OutboxPersister OutboxPersister { get; }
 
-        public OutboxCleaner(OutboxPersister outboxPersister)
+        public OutboxCleaner(OutboxPersister outboxPersister, ReadOnlySettings settings)
         {
             OutboxPersister = outboxPersister;
+            this.settings = settings;
         }
 
         protected override Task OnStart(IMessageSession busSession)
@@ -21,7 +23,7 @@ namespace NServiceBus.Features
 
             if (configValue == null)
             {
-                timeToKeepDeduplicationData = TimeSpan.FromDays(7);
+                timeToKeepDeduplicationData = settings.GetOrDefault<TimeSpan?>("Outbox.TimeToKeepDeduplicationData") ?? TimeSpan.FromDays(7);
             }
             else if (!TimeSpan.TryParse(configValue, out timeToKeepDeduplicationData))
             {
@@ -32,7 +34,7 @@ namespace NServiceBus.Features
 
             if (configValue == null)
             {
-                frequencyToRunDeduplicationDataCleanup = TimeSpan.FromMinutes(1);
+                frequencyToRunDeduplicationDataCleanup = settings.GetOrDefault<TimeSpan?>("Outbox.FrequencyToRunDeduplicationDataCleanup") ?? TimeSpan.FromMinutes(1);
             }
             else if (!TimeSpan.TryParse(configValue, out frequencyToRunDeduplicationDataCleanup))
             {
@@ -66,5 +68,6 @@ namespace NServiceBus.Features
         // ReSharper restore NotAccessedField.Local
         TimeSpan timeToKeepDeduplicationData;
         TimeSpan frequencyToRunDeduplicationDataCleanup;
+        ReadOnlySettings settings;
     }
 }

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -54,7 +54,7 @@ namespace NServiceBus.Features
             if (outboxEnabled)
             {
                 context.Container.ConfigureComponent(b => new OutboxPersister(sessionFactory, context.Settings.EndpointName().ToString()), DependencyLifecycle.SingleInstance);
-                context.RegisterStartupTask(b => new OutboxCleaner(b.Build<OutboxPersister>()));
+                context.RegisterStartupTask(b => new OutboxCleaner(b.Build<OutboxPersister>(), context.Settings));
             }
 
             var runInstaller = context.Settings.Get<bool>("NHibernate.Common.AutoUpdateSchema");

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -1,15 +1,18 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Configuration;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
-    using global::NHibernate.Cfg;
     using global::NHibernate.Mapping.ByCode;
     using global::NHibernate.Tool.hbm2ddl;
+    using NServiceBus.NHibernate.Outbox;
     using NServiceBus.Outbox.NHibernate;
+    using NServiceBus.Settings;
     using Persistence.NHibernate;
     using Persistence.NHibernate.Installer;
+    using Configuration = global::NHibernate.Cfg.Configuration;
 
     /// <summary>
     /// NHibernate Storage Session.
@@ -54,7 +57,13 @@ namespace NServiceBus.Features
             if (outboxEnabled)
             {
                 context.Container.ConfigureComponent(b => new OutboxPersister(sessionFactory, context.Settings.EndpointName().ToString()), DependencyLifecycle.SingleInstance);
-                context.RegisterStartupTask(b => new OutboxCleaner(b.Build<OutboxPersister>(), context.Settings));
+
+                var timeToKeepDeduplicationData = GetConfiguredTimeSpan(context.Settings, TimeSpan.FromDays(7),
+                    NHibernateOutboxExtensions.TimeToKeepDeduplicationDataAppSetting, NHibernateOutboxExtensions.TimeToKeepDeduplicationDataSettingsKey);
+                var frequencyToRunDeduplicationDataCleanup = GetConfiguredTimeSpan(context.Settings, TimeSpan.FromMinutes(1),
+                    NHibernateOutboxExtensions.FrequencyToRunDeduplicationDataCleanupAppSetting, NHibernateOutboxExtensions.FrequencyToRunDeduplicationDataCleanupSettingsKey);
+
+                context.RegisterStartupTask(b => new OutboxCleaner(b.Build<OutboxPersister>(), timeToKeepDeduplicationData, frequencyToRunDeduplicationDataCleanup));
             }
 
             var runInstaller = context.Settings.Get<bool>("NHibernate.Common.AutoUpdateSchema");
@@ -93,6 +102,24 @@ TSql Script:
             mapper.AddMapping<OutboxEntityMap>();
 
             config.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities());
+        }
+
+        static TimeSpan GetConfiguredTimeSpan(ReadOnlySettings settings, TimeSpan defaultValue, string appSettingsKey, string settingsKey)
+        {
+            var configValue = ConfigurationManager.AppSettings.Get(appSettingsKey);
+            TimeSpan result;
+
+            if (configValue == null)
+            {
+                return settings.GetOrDefault<TimeSpan?>(settingsKey) ?? defaultValue;
+            }
+
+            if (!TimeSpan.TryParse(configValue, out result))
+            {
+                throw new Exception($"Invalid value in '{appSettingsKey}' AppSetting. Please ensure it is a TimeSpan.");
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
Connects to #207

Related to https://github.com/Particular/NServiceBus.RavenDB/pull/271 and using the same API.

This would give a code option in addition to the current appSetting configuration option.

@Particular/nhibernate-persistence-maintainers @Particular/ravendb-persistence-maintainers