### PR TITLE
Initialize the subscription storage

### DIFF
--- a/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Features
     using System.Threading.Tasks;
     using global::NHibernate.Tool.hbm2ddl;
     using Persistence.NHibernate;
-    using Unicast.Subscriptions.MessageDrivenSubscriptions;
     using Unicast.Subscriptions.NHibernate;
     using Unicast.Subscriptions.NHibernate.Config;
     using Unicast.Subscriptions.NHibernate.Installer;
@@ -24,7 +23,7 @@ namespace NServiceBus.Features
         {
             DependsOn<MessageDrivenSubscriptions>();
 
-            // since the installers are registered even if the feature isn't enabled we need to make 
+            // since the installers are registered even if the feature isn't enabled we need to make
             // this a no-op of there is no "schema updater" available
             Defaults(c => c.Set<Installer.SchemaUpdater>(new Installer.SchemaUpdater()));
         }
@@ -51,11 +50,11 @@ namespace NServiceBus.Features
             var sessionFactory = config.Configuration.BuildSessionFactory();
             if (context.Settings.HasSetting(CacheExpirationSettingsKey))
             {
-                context.Container.ConfigureComponent<ISubscriptionStorage>(b => new CachedSubscriptionPersister(sessionFactory, context.Settings.Get<TimeSpan>(CacheExpirationSettingsKey)), DependencyLifecycle.SingleInstance);
+                context.Container.ConfigureComponent(b => new CachedSubscriptionPersister(sessionFactory, context.Settings.Get<TimeSpan>(CacheExpirationSettingsKey)), DependencyLifecycle.SingleInstance);
             }
             else
             {
-                context.Container.ConfigureComponent<ISubscriptionStorage>(b => new SubscriptionPersister(sessionFactory), DependencyLifecycle.SingleInstance);
+                context.Container.ConfigureComponent(b => new SubscriptionPersister(sessionFactory), DependencyLifecycle.SingleInstance);
             }
         }
 

--- a/src/NServiceBus.NHibernate/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/SubscriptionPersister.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
     using NServiceBus.Extensibility;
     using IsolationLevel = System.Data.IsolationLevel;
 
-    class SubscriptionPersister : IInitializableSubscriptionStorage
+    class SubscriptionPersister : ISubscriptionStorage
     {
 
         static ILog Logger = LogManager.GetLogger(typeof(ISubscriptionStorage));
@@ -88,7 +88,7 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
             }
         }
 
-        public void Init()
+        internal void Init()
         {
             using (new TransactionScope(TransactionScopeOption.Suppress))
             using (var session = sessionFactory.OpenStatelessSession())

--- a/src/NServiceBus.NHibernate/Subscriptions/SubscriptionPersister.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/SubscriptionPersister.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
     using NServiceBus.Extensibility;
     using IsolationLevel = System.Data.IsolationLevel;
 
-    class SubscriptionPersister : ISubscriptionStorage
+    class SubscriptionPersister : IInitializableSubscriptionStorage
     {
 
         static ILog Logger = LogManager.GetLogger(typeof(ISubscriptionStorage));


### PR DESCRIPTION
The subscription storage has an Init method which is never called. The core allows implementing `IInitializableSubscriptionStorage`. Then the core calls init on that type. I'm binding the class directly to the container. In theory with the interface scanning it should work. 

Happy to change it to the interface if you prefer.

@Particular/nhibernate-persistence-maintainers please review