### PR TITLE
Hotfix 7.0.1

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/SagaPersister/When_automapping_sagas.cs
+++ b/src/NServiceBus.NHibernate.Tests/SagaPersister/When_automapping_sagas.cs
@@ -33,7 +33,8 @@ namespace NServiceBus.SagaPersisters.NHibernate.Tests
                 typeof(DerivedFromTestSagaWithTableNameAttributeActualSaga), typeof(DerivedFromTestSagaWithTableNameAttribute),
                 typeof(TestSagaWithTableNameAttributeActualSaga), typeof(TestSagaWithTableNameAttribute),
                 typeof(SagaWithVersionedPropertyAttributeActualSaga), typeof(SagaWithVersionedPropertyAttribute),
-                typeof(SagaWithoutVersionedPropertyAttributeActualSaga), typeof(SagaWithoutVersionedPropertyAttribute)
+                typeof(SagaWithoutVersionedPropertyAttributeActualSaga), typeof(SagaWithoutVersionedPropertyAttribute),
+                typeof(object)
             };
             metaModel.Initialize(types);
             settings.Set<SagaMetadataCollection>(metaModel);

--- a/src/NServiceBus.NHibernate/SagaPersisters/SagaModelMapper.cs
+++ b/src/NServiceBus.NHibernate/SagaPersisters/SagaModelMapper.cs
@@ -264,6 +264,10 @@ namespace NServiceBus.SagaPersisters.NHibernate.AutoPersistence
                 return; //We skip user abstract classes
             }
 
+            if (rootEntity == typeof(object))
+            {
+                return;//skip object as that will result in mapping all its derivatives
+            }
             entityTypes.Add(rootEntity, sagaMetadata);
 
             var propertyInfos = rootEntity.GetProperties();


### PR DESCRIPTION
Hi Everyone,

We've just released `NServiceBus.NHibernate` `7.0.1`

As part of this release we had [7 commits](https://github.com/Particular/NServiceBus.NHibernate/compare/7.0.0...7.0.1) closing [1 issue](https://github.com/Particular/NServiceBus.NHibernate/issues?milestone=38&state=closed) closed.

__Fixed bugs__

- [__#239__](https://github.com/Particular/NServiceBus.NHibernate/issues/239) Saga mapping will auto map all types when the types to scan contains type System.Object

#### How to know if you are affected

You are affected if

* You want to use auto mapped sagas but have a handler that processes messages of type System.Object (`IHandleMessages<object>`).


#### Symptoms

Some exceptions that can occur immediately at startup of the endpoint.

InvalidCastException:

>  System.InvalidCastException: Unable to cast object of type 'System.Reflection.RtFieldInfo' to type 'System.Reflection.PropertyInfo'.

NHibernate.InvalidProxyTypeException:

> NHibernate.InvalidProxyTypeException : The following types may not be used as proxies:
> XXXXX: method get_Property should be 'public/protected virtual' or 'protected internal virtual'

#### Should you upgrade immediately

As this error can only occur at startup and no data loss can happen it is only needed to upgrade if the mentioned symptoms prevent the endpoint from starting.

You can download the updated version and see the full release notes here: https://github.com/Particular/NServiceBus.NHibernate/releases/tag/7.0.1

With thanks,

Particular Software

Please read our [release policy](http://docs.particular.net/nservicebus/release-policy) for more details.



