### PR TITLE
Outbox cleanup circuit breaker

### DIFF
--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Outbox\IOutboxRecord.cs" />
     <Compile Include="Outbox\OutboxConfig.cs" />
     <Compile Include="Outbox\OutboxRecord.cs" />
+    <Compile Include="RepeatedFailuresOverTimeCircuitBreaker.cs" />
     <Compile Include="SynchronizedStorage\INHibernateSynchronizedStorageSession.cs" />
     <Compile Include="SynchronizedStorage\NHibernateAmbientTransactionSynchronizedStorageSession.cs" />
     <Compile Include="Obsoletes\NHibernateStorageContext.cs" />

--- a/src/NServiceBus.NHibernate/Outbox/OutboxCleaner.cs
+++ b/src/NServiceBus.NHibernate/Outbox/OutboxCleaner.cs
@@ -7,9 +7,11 @@ namespace NServiceBus.Features
 
     class OutboxCleaner : FeatureStartupTask
     {
-        public OutboxCleaner(INHibernateOutboxStorage outboxPersister)
+
+        public OutboxCleaner(INHibernateOutboxStorage outboxPersister, CriticalError criticalError)
         {
             this.outboxPersister = outboxPersister;
+            this.criticalError = criticalError;
         }
 
         protected override Task OnStart(IMessageSession busSession)
@@ -36,6 +38,25 @@ namespace NServiceBus.Features
                 throw new Exception("Invalid value in \"NServiceBus/Outbox/NHibernate/FrequencyToRunDeduplicationDataCleanup\" AppSetting. Please ensure it is a TimeSpan.");
             }
 
+            var key = "NServiceBus/Outbox/NHibernate/TimeToWaitBeforeTriggeringCriticalErrorWhenCleanupTaskFails";
+
+            configValue = ConfigurationManager.AppSettings.Get(key);
+
+            if (configValue == null)
+            {
+                timeToWaitBeforeTriggeringCriticalError = TimeSpan.FromMinutes(2);
+            }
+            else if (!TimeSpan.TryParse(configValue, out timeToWaitBeforeTriggeringCriticalError))
+            {
+                throw new Exception($"Invalid value in \"{key}\" AppSetting. Please ensure it is a TimeSpan.");
+            }
+
+            circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker(
+                "OutboxCleanupTaskConnectivity",
+                timeToWaitBeforeTriggeringCriticalError,
+                ex => criticalError.Raise("Repeated failures when purging expired outbox records from storage, endpoint will be terminated.", ex)
+                );
+
             cleanupTimer = new Timer(PerformCleanup, null, TimeSpan.FromMinutes(1), frequencyToRunDeduplicationDataCleanup);
 
             return Task.FromResult(true);
@@ -55,7 +76,15 @@ namespace NServiceBus.Features
 
         void PerformCleanup(object state)
         {
-            outboxPersister.RemoveEntriesOlderThan(DateTime.UtcNow - timeToKeepDeduplicationData);
+            try
+            {
+                outboxPersister.RemoveEntriesOlderThan(DateTime.UtcNow - timeToKeepDeduplicationData);
+                circuitBreaker.Success();
+            }
+            catch (Exception ex)
+            {
+                circuitBreaker.Failure(ex);
+            }
         }
 
         // ReSharper disable NotAccessedField.Local
@@ -64,5 +93,8 @@ namespace NServiceBus.Features
         TimeSpan frequencyToRunDeduplicationDataCleanup;
         INHibernateOutboxStorage outboxPersister;
         TimeSpan timeToKeepDeduplicationData;
+        RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
+        TimeSpan timeToWaitBeforeTriggeringCriticalError;
+        CriticalError criticalError;
     }
 }

--- a/src/NServiceBus.NHibernate/Outbox/OutboxCleaner.cs
+++ b/src/NServiceBus.NHibernate/Outbox/OutboxCleaner.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.Features
 
     class OutboxCleaner : FeatureStartupTask
     {
-
         public OutboxCleaner(INHibernateOutboxStorage outboxPersister, CriticalError criticalError)
         {
             this.outboxPersister = outboxPersister;
@@ -54,8 +53,8 @@ namespace NServiceBus.Features
             circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker(
                 "OutboxCleanupTaskConnectivity",
                 timeToWaitBeforeTriggeringCriticalError,
-                ex => criticalError.Raise("Repeated failures when purging expired outbox records from storage, endpoint will be terminated.", ex)
-                );
+                ex => criticalError.Raise("Failed to clean the Oubox.", ex)
+            );
 
             cleanupTimer = new Timer(PerformCleanup, null, TimeSpan.FromMinutes(1), frequencyToRunDeduplicationDataCleanup);
 
@@ -87,14 +86,15 @@ namespace NServiceBus.Features
             }
         }
 
+        RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
+
         // ReSharper disable NotAccessedField.Local
         Timer cleanupTimer;
         // ReSharper restore NotAccessedField.Local
+        CriticalError criticalError;
         TimeSpan frequencyToRunDeduplicationDataCleanup;
         INHibernateOutboxStorage outboxPersister;
         TimeSpan timeToKeepDeduplicationData;
-        RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
         TimeSpan timeToWaitBeforeTriggeringCriticalError;
-        CriticalError criticalError;
     }
 }

--- a/src/NServiceBus.NHibernate/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/src/NServiceBus.NHibernate/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -1,0 +1,68 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Threading;
+    using Logging;
+
+    class RepeatedFailuresOverTimeCircuitBreaker : IDisposable
+    {
+        public RepeatedFailuresOverTimeCircuitBreaker(string name, TimeSpan timeToWaitBeforeTriggering, Action<Exception> triggerAction)
+        {
+            this.name = name;
+            this.triggerAction = triggerAction;
+            this.timeToWaitBeforeTriggering = timeToWaitBeforeTriggering;
+
+            timer = new Timer(CircuitBreakerTriggered);
+        }
+
+        public void Success()
+        {
+            var oldValue = Interlocked.Exchange(ref failureCount, 0);
+
+            if (oldValue == 0)
+            {
+                return;
+            }
+
+            timer.Change(System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite);
+            Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+        }
+
+        public void Failure(Exception exception)
+        {
+            lastException = exception;
+            var newValue = Interlocked.Increment(ref failureCount);
+
+            if (newValue == 1)
+            {
+                timer.Change(timeToWaitBeforeTriggering, NoPeriodicTriggering);
+                Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
+            }
+        }
+
+        public void Dispose()
+        {
+            //Injected
+        }
+
+        void CircuitBreakerTriggered(object state)
+        {
+            if (Interlocked.Read(ref failureCount) > 0)
+            {
+                Logger.WarnFormat("The circuit breaker for {0} will now be triggered", name);
+                triggerAction(lastException);
+            }
+        }
+
+        long failureCount;
+        Exception lastException;
+
+        string name;
+        Timer timer;
+        TimeSpan timeToWaitBeforeTriggering;
+        Action<Exception> triggerAction;
+
+        static TimeSpan NoPeriodicTriggering = TimeSpan.FromMilliseconds(-1);
+        static ILog Logger = LogManager.GetLogger<RepeatedFailuresOverTimeCircuitBreaker>();
+    }
+}

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Features
                 s.SetDefault(OutboxMappingSettingsKey, typeof(OutboxRecordMapping));
             });
 
-            // since the installers are registered even if the feature isn't enabled we need to make 
+            // since the installers are registered even if the feature isn't enabled we need to make
             // this a no-op of there is no "schema updater" available
             Defaults(c => c.Set<Installer.SchemaUpdater>(new Installer.SchemaUpdater()));
         }
@@ -64,7 +64,7 @@ namespace NServiceBus.Features
                 var factory = context.Settings.Get<IOutboxPersisterFactory>();
                 var persister = factory.Create(sessionFactory, context.Settings.EndpointName());
                 context.Container.ConfigureComponent(b => persister, DependencyLifecycle.SingleInstance);
-                context.RegisterStartupTask(b => new OutboxCleaner(persister));
+                context.RegisterStartupTask(b => new OutboxCleaner(persister, b.Build<CriticalError>()));
             }
 
             var runInstaller = context.Settings.Get<bool>("NHibernate.Common.AutoUpdateSchema");


### PR DESCRIPTION
Quick draft to resolve https://github.com/Particular/NServiceBus.NHibernate/issues/241

I have put the circuit breaker creation in the cleaner as that already contains configuration. In core circuitbreakers are created in the feature which seems to make more sense but that felt strange to do here unless that configuration value retrieval code is moved to the feature too.