### PR TITLE
Outbox cleanup circuit breaker (#242)

### DIFF
--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -84,6 +84,7 @@
   <ItemGroup>
     <Compile Include="Internal\NHibernateConfiguration.cs" />
     <Compile Include="Internal\ObjectSerializer.cs" />
+    <Compile Include="RepeatedFailuresOverTimeCircuitBreaker.cs" />
     <Compile Include="SynchronizedStorage\INHibernateSynchronizedStorageSession.cs" />
     <Compile Include="SynchronizedStorage\NHibernateAmbientTransactionSynchronizedStorageSession.cs" />
     <Compile Include="Obsoletes\NHibernateStorageContext.cs" />

--- a/src/NServiceBus.NHibernate/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/src/NServiceBus.NHibernate/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -1,0 +1,68 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Threading;
+    using Logging;
+
+    class RepeatedFailuresOverTimeCircuitBreaker : IDisposable
+    {
+        public RepeatedFailuresOverTimeCircuitBreaker(string name, TimeSpan timeToWaitBeforeTriggering, Action<Exception> triggerAction)
+        {
+            this.name = name;
+            this.triggerAction = triggerAction;
+            this.timeToWaitBeforeTriggering = timeToWaitBeforeTriggering;
+
+            timer = new Timer(CircuitBreakerTriggered);
+        }
+
+        public void Success()
+        {
+            var oldValue = Interlocked.Exchange(ref failureCount, 0);
+
+            if (oldValue == 0)
+            {
+                return;
+            }
+
+            timer.Change(System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite);
+            Logger.InfoFormat("The circuit breaker for {0} is now disarmed", name);
+        }
+
+        public void Failure(Exception exception)
+        {
+            lastException = exception;
+            var newValue = Interlocked.Increment(ref failureCount);
+
+            if (newValue == 1)
+            {
+                timer.Change(timeToWaitBeforeTriggering, NoPeriodicTriggering);
+                Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
+            }
+        }
+
+        public void Dispose()
+        {
+            //Injected
+        }
+
+        void CircuitBreakerTriggered(object state)
+        {
+            if (Interlocked.Read(ref failureCount) > 0)
+            {
+                Logger.WarnFormat("The circuit breaker for {0} will now be triggered", name);
+                triggerAction(lastException);
+            }
+        }
+
+        long failureCount;
+        Exception lastException;
+
+        string name;
+        Timer timer;
+        TimeSpan timeToWaitBeforeTriggering;
+        Action<Exception> triggerAction;
+
+        static TimeSpan NoPeriodicTriggering = TimeSpan.FromMilliseconds(-1);
+        static ILog Logger = LogManager.GetLogger<RepeatedFailuresOverTimeCircuitBreaker>();
+    }
+}

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Features
 
             Defaults(s => s.SetDefault<SharedMappings>(new SharedMappings()));
 
-            // since the installers are registered even if the feature isn't enabled we need to make 
+            // since the installers are registered even if the feature isn't enabled we need to make
             // this a no-op of there is no "schema updater" available
             Defaults(c => c.Set<Installer.SchemaUpdater>(new Installer.SchemaUpdater()));
         }
@@ -54,7 +54,7 @@ namespace NServiceBus.Features
             if (outboxEnabled)
             {
                 context.Container.ConfigureComponent(b => new OutboxPersister(sessionFactory, context.Settings.EndpointName().ToString()), DependencyLifecycle.SingleInstance);
-                context.RegisterStartupTask(b => new OutboxCleaner(b.Build<OutboxPersister>()));
+                context.RegisterStartupTask(b => new OutboxCleaner(b.Build<OutboxPersister>(), b.Build<CriticalError>()));
             }
 
             var runInstaller = context.Settings.Get<bool>("NHibernate.Common.AutoUpdateSchema");


### PR DESCRIPTION
* Imported RepeatedFailuresOverTimeCircuitBreaker, removed unneeded code and used it in OutboxCleaner as that also does other initialization.

* Simplify critical error message

* Format code

* Extract time parametes into constants