### PR TITLE
Fixes the schema generation bug

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/Outbox/When_adding_outbox_messages.cs
+++ b/src/NServiceBus.NHibernate.Tests/Outbox/When_adding_outbox_messages.cs
@@ -9,12 +9,10 @@ namespace NServiceBus.NHibernate.Tests.Outbox
     using global::NHibernate.Cfg;
     using global::NHibernate.Mapping.ByCode;
     using global::NHibernate.Mapping.ByCode.Conformist;
-    using global::NHibernate.Tool.hbm2ddl;
     using NServiceBus.Extensibility;
     using NServiceBus.Outbox;
     using NServiceBus.Outbox.NHibernate;
     using NServiceBus.Persistence.NHibernate;
-    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using NUnit.Framework;
     using Environment = global::NHibernate.Cfg.Environment;
 

--- a/src/NServiceBus.NHibernate.Tests/Outbox/When_adding_outbox_messages.cs
+++ b/src/NServiceBus.NHibernate.Tests/Outbox/When_adding_outbox_messages.cs
@@ -14,6 +14,7 @@ namespace NServiceBus.NHibernate.Tests.Outbox
     using NServiceBus.Outbox;
     using NServiceBus.Outbox.NHibernate;
     using NServiceBus.Persistence.NHibernate;
+    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using NUnit.Framework;
     using Environment = global::NHibernate.Cfg.Environment;
 
@@ -51,7 +52,7 @@ namespace NServiceBus.NHibernate.Tests.Outbox
 
             configuration.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities());
 
-            new SchemaUpdate(configuration).Execute(false, true);
+            new OptimizedSchemaUpdate(configuration).Execute(false, true);
 
             sessionFactory = configuration.BuildSessionFactory();
 

--- a/src/NServiceBus.NHibernate.Tests/SagaPersister/InMemoryFixture.cs
+++ b/src/NServiceBus.NHibernate.Tests/SagaPersister/InMemoryFixture.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.SagaPersisters.NHibernate.Tests
     using global::NHibernate;
     using global::NHibernate.Tool.hbm2ddl;
     using NServiceBus.Sagas;
+    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using NUnit.Framework;
 
     class InMemoryFixture<T> where T : Saga
@@ -36,7 +37,7 @@ namespace NServiceBus.SagaPersisters.NHibernate.Tests
 
             SessionFactory = configuration.BuildSessionFactory();
 
-            new SchemaUpdate(configuration).Execute(false, true);
+            new OptimizedSchemaUpdate(configuration).Execute(false, true);
 
             SagaPersister = new SagaPersister();
         }

--- a/src/NServiceBus.NHibernate.Tests/SagaPersister/InMemoryFixture.cs
+++ b/src/NServiceBus.NHibernate.Tests/SagaPersister/InMemoryFixture.cs
@@ -4,9 +4,7 @@ namespace NServiceBus.SagaPersisters.NHibernate.Tests
     using System.IO;
     using AutoPersistence;
     using global::NHibernate;
-    using global::NHibernate.Tool.hbm2ddl;
     using NServiceBus.Sagas;
-    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using NUnit.Framework;
 
     class InMemoryFixture<T> where T : Saga

--- a/src/NServiceBus.NHibernate/Deduplication/NHibernateGatewayDeduplication.cs
+++ b/src/NServiceBus.NHibernate/Deduplication/NHibernateGatewayDeduplication.cs
@@ -3,9 +3,10 @@ namespace NServiceBus.Features
     using System.Threading.Tasks;
     using Deduplication.NHibernate.Config;
     using Deduplication.NHibernate;
-    using Deduplication.NHibernate.Installer;
     using global::NHibernate.Tool.hbm2ddl;
+    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
+    using Installer = NServiceBus.Deduplication.NHibernate.Installer.Installer;
 
     /// <summary>
     /// NHibernate Gateway Deduplication.
@@ -37,7 +38,7 @@ namespace NServiceBus.Features
             {
                 context.Settings.Get<Installer.SchemaUpdater>().Execute = identity =>
                 {
-                    new SchemaUpdate(config.Configuration).Execute(false, true);
+                    new OptimizedSchemaUpdate(config.Configuration).Execute(false, true);
 
                     return Task.FromResult(0);
                 };

--- a/src/NServiceBus.NHibernate/Deduplication/NHibernateGatewayDeduplication.cs
+++ b/src/NServiceBus.NHibernate/Deduplication/NHibernateGatewayDeduplication.cs
@@ -3,8 +3,6 @@ namespace NServiceBus.Features
     using System.Threading.Tasks;
     using Deduplication.NHibernate.Config;
     using Deduplication.NHibernate;
-    using global::NHibernate.Tool.hbm2ddl;
-    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
     using Installer = NServiceBus.Deduplication.NHibernate.Installer.Installer;
 

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -133,7 +133,7 @@
     <Compile Include="SynchronizedStorageSessionExtensions.cs" />
     <Compile Include="TimeoutPersisters\TimeoutEntityMap.cs" />
     <Compile Include="TimeoutPersisters\Installer\Installer.cs" />
-    <Compile Include="TimeoutPersisters\OptimizedSchemaUpdate.cs" />
+    <Compile Include="OptimizedSchemaUpdate.cs" />
     <Compile Include="TimeoutPersisters\NHibernateTimeoutStorage.cs" />
     <Compile Include="TimeoutPersisters\TimeoutConfig.cs" />
     <Compile Include="TimeoutPersisters\TimeoutEntity.cs" />

--- a/src/NServiceBus.NHibernate/OptimizedSchemaUpdate.cs
+++ b/src/NServiceBus.NHibernate/OptimizedSchemaUpdate.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.TimeoutPersisters.NHibernate.Installer
+namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
@@ -13,11 +13,12 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Installer
 
     class OptimizedSchemaUpdate
     {
-        public OptimizedSchemaUpdate(Configuration cfg) : this(cfg, cfg.Properties)
+        public OptimizedSchemaUpdate(global::NHibernate.Cfg.Configuration cfg) 
+            : this(cfg, cfg.Properties)
         {
         }
 
-        public OptimizedSchemaUpdate(Configuration cfg, IDictionary<string, string> configProperties)
+        public OptimizedSchemaUpdate(global::NHibernate.Cfg.Configuration cfg, IDictionary<string, string> configProperties)
         {
             configuration = cfg;
             dialect = Dialect.GetDialect(configProperties);
@@ -101,7 +102,10 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Installer
 
                     if (dialectScopes.Contains(dialect.GetType().FullName))
                     {
-                        sql = sql.Replace("primary key (Id)", "primary key nonclustered (Id)");
+                        if (sql.StartsWith("create table TimeoutEntity"))
+                        {
+                            sql = sql.Replace("primary key (Id)", "primary key nonclustered (Id)");
+                        }
                         sql = sql.Replace("create index TimeoutEntity_EndpointIdx on TimeoutEntity (Time, Endpoint)", "create clustered index TimeoutEntity_EndpointIdx on TimeoutEntity (Endpoint, Time)");
                     }
 
@@ -147,7 +151,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Installer
         }
 
         static IInternalLogger log = LoggerProvider.LoggerFor(typeof(OptimizedSchemaUpdate));
-        Configuration configuration;
+        global::NHibernate.Cfg.Configuration configuration;
         IConnectionHelper connectionHelper;
         Dialect dialect;
         List<Exception> exceptions;

--- a/src/NServiceBus.NHibernate/OptimizedSchemaUpdate.cs
+++ b/src/NServiceBus.NHibernate/OptimizedSchemaUpdate.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
         {
         }
 
-        public OptimizedSchemaUpdate(global::NHibernate.Cfg.Configuration cfg, IDictionary<string, string> configProperties)
+        OptimizedSchemaUpdate(global::NHibernate.Cfg.Configuration cfg, IDictionary<string, string> configProperties)
         {
             configuration = cfg;
             dialect = Dialect.GetDialect(configProperties);

--- a/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
@@ -3,10 +3,11 @@ namespace NServiceBus.Features
     using System;
     using System.Threading.Tasks;
     using global::NHibernate.Tool.hbm2ddl;
+    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
     using Unicast.Subscriptions.NHibernate;
     using Unicast.Subscriptions.NHibernate.Config;
-    using Unicast.Subscriptions.NHibernate.Installer;
+    using Installer = NServiceBus.Unicast.Subscriptions.NHibernate.Installer.Installer;
 
     /// <summary>
     /// NHibernate Subscription Storage
@@ -41,8 +42,7 @@ namespace NServiceBus.Features
             {
                 context.Settings.Get<Installer.SchemaUpdater>().Execute = identity =>
                 {
-                    new SchemaUpdate(config.Configuration).Execute(false, true);
-
+                    new OptimizedSchemaUpdate(config.Configuration).Execute(false, true);
                     return Task.FromResult(0);
                 };
             }

--- a/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
@@ -2,8 +2,6 @@ namespace NServiceBus.Features
 {
     using System;
     using System.Threading.Tasks;
-    using global::NHibernate.Tool.hbm2ddl;
-    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
     using Unicast.Subscriptions.NHibernate;
     using Unicast.Subscriptions.NHibernate.Config;

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -9,8 +9,9 @@ namespace NServiceBus.Features
     using global::NHibernate.Tool.hbm2ddl;
     using NServiceBus.NHibernate.Outbox;
     using NServiceBus.Outbox.NHibernate;
+    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
-    using Persistence.NHibernate.Installer;
+    using Installer = NServiceBus.Persistence.NHibernate.Installer.Installer;
 
     /// <summary>
     /// NHibernate Storage Session.
@@ -73,7 +74,7 @@ namespace NServiceBus.Features
             {
                 context.Settings.Get<Installer.SchemaUpdater>().Execute = identity =>
                 {
-                    var schemaUpdate = new SchemaUpdate(config.Configuration);
+                    var schemaUpdate = new OptimizedSchemaUpdate(config.Configuration);
                     var sb = new StringBuilder();
                     schemaUpdate.Execute(s => sb.AppendLine(s), true);
 

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -6,10 +6,8 @@ namespace NServiceBus.Features
     using System.Threading.Tasks;
     using global::NHibernate.Cfg;
     using global::NHibernate.Mapping.ByCode;
-    using global::NHibernate.Tool.hbm2ddl;
     using NServiceBus.NHibernate.Outbox;
     using NServiceBus.Outbox.NHibernate;
-    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
     using Installer = NServiceBus.Persistence.NHibernate.Installer.Installer;
 


### PR DESCRIPTION
 * Uses `OptimizedSchemaUpdate` for all schema updates
 * Adds condition to `OptimizedSchemaUpdate` to only modify timeout table PK