### PR TITLE
Close connection even if session flush throws

### DIFF
--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateAmbientTransactionSynchronizedStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateAmbientTransactionSynchronizedStorageSession.cs
@@ -23,14 +23,20 @@
 
         public void Dispose()
         {
-            if (session.IsValueCreated)
+            try
             {
-                session.Value.Flush();
-                session.Value.Dispose();
+                if (session.IsValueCreated)
+                {
+                    session.Value.Flush();
+                    session.Value.Dispose();
+                }
             }
-            if (connection.IsValueCreated)
+            finally
             {
-                connection.Value.Dispose();
+                if (connection.IsValueCreated)
+                {
+                    connection.Value.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
## Symptoms

When [business data access with NHibernate persistence](https://docs.particular.net/nservicebus/nhibernate/accessing-data) fails, the database connection opened for the failed NHibernate session will not be closed.

Consistent rate of data access errors leads to ADO .NET connection pool exhaustion and endpoint shutdown.

## Who is affected?

Users of NHibernate persistence that use `SynchronizedStorageSession` are affected.

Related to #255 