### PR TITLE
Use CombGuid as timeout identifier

### DIFF
--- a/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutEntityMap.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutEntityMap.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Config
     {
         public TimeoutEntityMap()
         {
-            Id(x => x.Id, m => m.Generator(Generators.Assigned));
+            Id(x => x.Id, m => m.Generator(Generators.GuidComb));
             Property(p => p.State, pm =>
             {
                 pm.Type(NHibernateUtil.BinaryBlob);

--- a/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
@@ -86,23 +86,23 @@ namespace NServiceBus.TimeoutPersisters.NHibernate
 
         public async Task Add(TimeoutData timeout, ContextBag context)
         {
-            var timeoutId = Guid.NewGuid();
             using (var session = await OpenSession(context).ConfigureAwait(false))
             {
-                session.Session().Save(new TimeoutEntity
+                var timeoutEntity = new TimeoutEntity
                 {
-                    Id = timeoutId,
                     Destination = timeout.Destination,
                     SagaId = timeout.SagaId,
                     State = timeout.State,
                     Time = timeout.Time,
                     Headers = ConvertDictionaryToString(timeout.Headers),
                     Endpoint = timeout.OwningTimeoutManager
-                });
-                await session.CompleteAsync().ConfigureAwait(false);
-            }
+                };
 
-            timeout.Id = timeoutId.ToString();
+                var timeoutId = (Guid) session.Session().Save(timeoutEntity);
+                await session.CompleteAsync().ConfigureAwait(false);
+
+                timeout.Id = timeoutId.ToString();
+            }
         }
 
         public async Task<bool> TryRemove(string timeoutId, ContextBag context)


### PR DESCRIPTION
## Symptoms

NHibernate persistence uses `Guid.NewGuid()` method to generate identifiers when [storing timeout messages](https://docs.particular.net/nservicebus/messaging/timeout-manager#storing-timeout-messages). This results in index fragmentation and low performance of operations on the `TimeoutEntity` table.

## Who is affected?

Users of NHibernate persistence that use [delayed delivery](https://docs.particular.net/nservicebus/messaging/delayed-delivery), [delayed retries](https://docs.particular.net/nservicebus/recoverability/configure-delayed-retries) or [saga timeouts](https://docs.particular.net/nservicebus/sagas/timeouts) are affected on all transports other than [Azure Service Bus](https://docs.particular.net/nservicebus/azure-service-bus/).