### PR TITLE
WrapHandlersInATransactionScope causes synchronized session transaction to lose data

### DIFF
--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -316,8 +316,8 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="ConfigureEndpointNHibernatePersistence.cs" />
     <Compile Include="EndpointConfigurer.cs" />
-    <Compile Include="When_using_transaction_scope_and_outbox.cs" />
-    <Compile Include="When_receiving_a_message_with_customized_outbox_record_mapping.cs" />
+    <Compile Include="When_using_outbox_with_transport_in_transaction_scope_mode.cs" />
+    <Compile Include="When_using_outbox_and_wrapping_handlers_in_tx_scope.cs" />
     <Compile Include="When_user_supplies_NH_Configuration.cs" />
     <Compile Include="When_using_hbms.cs" />
     <Compile Include="When_saga_contains_nested_collection_without_parent_relation.cs" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -316,6 +316,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="ConfigureEndpointNHibernatePersistence.cs" />
     <Compile Include="EndpointConfigurer.cs" />
+    <Compile Include="When_using_transaction_scope_and_outbox.cs" />
     <Compile Include="When_receiving_a_message_with_customized_outbox_record_mapping.cs" />
     <Compile Include="When_user_supplies_NH_Configuration.cs" />
     <Compile Include="When_using_hbms.cs" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests/When_using_outbox_and_wrapping_handlers_in_tx_scope.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/When_using_outbox_and_wrapping_handlers_in_tx_scope.cs
@@ -9,17 +9,17 @@
     using NServiceBus.Logging;
     using NUnit.Framework;
 
-    public class When_using_transaction_scope_and_outbox : NServiceBusAcceptanceTest
+    public class When_using_outbox_and_wrapping_handlers_in_tx_scope : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Persist_saga_and_log_warning()
+        public async Task Should_persist_saga_and_log_warning()
         {
             /*
              * DoNotFailOnErrorMessages is used here because the original problem discovered with the code was causing data loss due to incorrect transaction
              * handling in the outbox feature while FLR was enabled.
              */
             var ctx = await Scenario.Define<Context>()
-                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.When(async session =>
+                .WithEndpoint<OutboxTransactionScopeSagaEndpoint>(b => b.When(async session =>
                 {
                     var sagaId = Guid.NewGuid();
                     await session.SendLocal(new StartSagaMessage
@@ -45,9 +45,9 @@
             public bool Done { get; set; }
         }
 
-        public class NonDtcReceivingEndpoint : EndpointConfigurationBuilder
+        public class OutboxTransactionScopeSagaEndpoint : EndpointConfigurationBuilder
         {
-            public NonDtcReceivingEndpoint()
+            public OutboxTransactionScopeSagaEndpoint()
             {
                 EndpointSetup<DefaultServer>(b =>
                 {
@@ -84,7 +84,7 @@
                 }
             }
 
-            class OutboxTransactionScopeSagaData : ContainSagaData
+            public class OutboxTransactionScopeSagaData : ContainSagaData
             {
                 public virtual bool Started { get; set; }
                 public virtual Guid UniqueId { get; set; }

--- a/src/NServiceBus.NHibernate.AcceptanceTests/When_using_outbox_with_transport_in_transaction_scope_mode.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/When_using_outbox_with_transport_in_transaction_scope_mode.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Configuration.AdvanceExtensibility;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_outbox_with_transport_in_transaction_scope_mode : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_throw_exception()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.When(session => session.SendLocal(new MyMessage())).DoNotFailOnErrorMessages())
+                .Done(c => c.FailedMessages.Any())
+                .Run(TimeSpan.FromSeconds(20));
+
+            Assert.IsTrue(ctx.FailedMessages.Values.SelectMany(x => x).Any(m => m.Exception.Message.StartsWith("The endpoint is configured to use Outbox but a TransactionScope has been detected.")));
+        }
+
+        class Context : ScenarioContext
+        {
+        }
+
+        public class NonDtcReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDtcReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>((b, r) =>
+                {
+                    b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                    b.EnableOutbox();
+                    b.UseTransport(r.GetTransportType()).Transactions(TransportTransactionMode.TransactionScope);
+                });
+            }
+            
+            class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate.AcceptanceTests/When_using_transaction_scope_and_outbox.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/When_using_transaction_scope_and_outbox.cs
@@ -1,0 +1,106 @@
+﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Configuration.AdvanceExtensibility;
+    using EndpointTemplates;
+    using NServiceBus.Logging;
+    using NUnit.Framework;
+
+    public class When_using_transaction_scope_and_outbox : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Persist_saga_and_log_warning()
+        {
+            /*
+             * DoNotFailOnErrorMessages is used here because the original problem discovered with the code was causing data loss due to incorrect transaction
+             * handling in the outbox feature while FLR was enabled.
+             */
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.When(async session =>
+                {
+                    var sagaId = Guid.NewGuid();
+                    await session.SendLocal(new StartSagaMessage
+                    {
+                        UniqueId = sagaId
+                    }).ConfigureAwait(false);
+                    await session.SendLocal(new CheckSagaMessage
+                    {
+                        UniqueId = sagaId
+                    }).ConfigureAwait(false);
+                }).DoNotFailOnErrorMessages())
+                .Done(c => c.Done)
+                .Run(TimeSpan.FromSeconds(20));
+
+            Assert.IsTrue(ctx.Done);
+            Assert.IsTrue(ctx.SagaStarted);
+            Assert.IsTrue(ctx.Logs.Any(x => x.Level == LogLevel.Warn && x.Message.StartsWith("The endpoint is configured to use Outbox but a TransactionScope has been detected.")));
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool SagaStarted { get; set; }
+            public bool Done { get; set; }
+        }
+
+        public class NonDtcReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDtcReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                    b.EnableOutbox();
+                    b.UnitOfWork().WrapHandlersInATransactionScope();
+                    b.LimitMessageProcessingConcurrencyTo(1); //To ensure saga is properly created before we check it.
+                });
+            }
+            
+            class OutboxTransactionScopeSaga : Saga<OutboxTransactionScopeSagaData>,
+                IAmStartedByMessages<StartSagaMessage>,
+                IAmStartedByMessages<CheckSagaMessage>
+            {
+                public Context Context { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<OutboxTransactionScopeSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.UniqueId).ToSaga(s => s.UniqueId);
+                    mapper.ConfigureMapping<CheckSagaMessage>(m => m.UniqueId).ToSaga(s => s.UniqueId);
+                }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    Data.Started = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(CheckSagaMessage message, IMessageHandlerContext context)
+                {
+                    Context.SagaStarted = Data.Started;
+                    Context.Done = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            class OutboxTransactionScopeSagaData : ContainSagaData
+            {
+                public virtual bool Started { get; set; }
+                public virtual Guid UniqueId { get; set; }
+            }
+        }
+
+        public class StartSagaMessage : IMessage
+        {
+            public virtual Guid UniqueId { get; set; }
+        }
+
+        public class CheckSagaMessage : IMessage
+        {
+            public virtual Guid UniqueId { get; set; }
+        }
+    }
+
+    
+}

--- a/src/NServiceBus.NHibernate/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.NHibernate/Outbox/OutboxPersister.cs
@@ -8,7 +8,6 @@
     using global::NHibernate;
     using global::NHibernate.Criterion;
     using NServiceBus.Extensibility;
-    using NServiceBus.Logging;
     using NServiceBus.Outbox;
     using NServiceBus.Outbox.NHibernate;
     using IsolationLevel = System.Data.IsolationLevel;
@@ -16,7 +15,6 @@
     class OutboxPersister<TEntity> : INHibernateOutboxStorage
         where TEntity : class, IOutboxRecord, new()
     {
-        static ILog Log = LogManager.GetLogger<OutboxPersister<TEntity>>();
         ISessionFactory sessionFactory;
         string endpointName;
 
@@ -35,7 +33,7 @@
 
             if (Transaction.Current != null)
             {
-                Log.Warn("The endpoint is configured to use Outbox but a TransactionScope has been detected. Outbox mode is not compatible with "
+                throw new Exception("The endpoint is configured to use Outbox but a TransactionScope has been detected. Outbox mode is not compatible with "
                     + $"TransactionScope. Do not configure the transport to use '{nameof(TransportTransactionMode.TransactionScope)}' transaction mode with Outbox.");
             }
 

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -8,9 +8,11 @@ namespace NServiceBus.Features
     using global::NHibernate.Mapping.ByCode;
     using global::NHibernate.Tool.hbm2ddl;
     using NServiceBus.NHibernate.Outbox;
+    using global::NHibernate.Transaction;
     using NServiceBus.Outbox.NHibernate;
     using Persistence.NHibernate;
     using Persistence.NHibernate.Installer;
+    using Environment = global::NHibernate.Cfg.Environment;
 
     /// <summary>
     /// NHibernate Storage Session.
@@ -48,6 +50,7 @@ namespace NServiceBus.Features
             if (outboxEnabled)
             {
                 sharedMappings.AddMapping(configuration => ApplyMappings(configuration, context));
+                config.Configuration.Properties[Environment.TransactionStrategy] = typeof(AdoNetTransactionFactory).FullName;
             }
 
             sharedMappings.ApplyTo(config.Configuration);

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateSynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateSynchronizedStorageAdapter.cs
@@ -8,6 +8,7 @@
     using global::NHibernate;
     using global::NHibernate.Impl;
     using NServiceBus.Extensibility;
+    using NServiceBus.Logging;
     using NServiceBus.Outbox;
     using NServiceBus.Outbox.NHibernate;
     using NServiceBus.Persistence;
@@ -17,6 +18,7 @@
     {
         ISessionFactory sessionFactory;
         static readonly Task<CompletableSynchronizedStorageSession> EmptyResult = Task.FromResult((CompletableSynchronizedStorageSession)null);
+        static ILog Log = LogManager.GetLogger<NHibernateSynchronizedStorageAdapter>();
 
         public NHibernateSynchronizedStorageAdapter(ISessionFactory sessionFactory)
         {
@@ -28,6 +30,12 @@
             var nhibernateTransaction = transaction as NHibernateOutboxTransaction;
             if (nhibernateTransaction != null)
             {
+                if (Transaction.Current != null)
+                {
+                    Log.Warn("The endpoint is configured to use Outbox but a TransactionScope has been detected. Outbox mode is not compatible with "
+                        + "TransactionScope. Do not use config.UnitOfWork().WrapHandlersInATransactionScope() when Outbox is enabled.");
+                }
+
                 CompletableSynchronizedStorageSession session = new NHibernateNativeTransactionSynchronizedStorageSession(nhibernateTransaction.Session, nhibernateTransaction.Transaction);
                 return Task.FromResult(session);
             }


### PR DESCRIPTION
Originally reported in #269

## Symptoms

Data changes done via synchronized storage session are lost and the incoming message is consumed. Resulting outgoing messages are dispatched normally resulting in ghost messages.

## Who's affected

User's who use Outbox and (e.g. accidentally) enable `WrapHandlersInATransactionScope`.