### PR TITLE
Unique constraints are not generated for saga correlation properties

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
+++ b/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
@@ -81,6 +81,7 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SagaPersister\InMemoryFixture.cs" />
     <Compile Include="Outbox\FakeDbConnectionProvider.cs" />
     <Compile Include="Outbox\MessageIdOutboxRecord.cs" />
     <Compile Include="Outbox\GuidOutboxRecord.cs" />
@@ -88,7 +89,6 @@
     <Compile Include="Outbox\When_deserializing_outbox_messages.cs" />
     <Compile Include="Persistence\NHibernateConfigurationBuilderTests.cs" />
     <Compile Include="SagaPersister\FakeConfigurationSource.cs" />
-    <Compile Include="SagaPersister\InMemoryFixture.cs" />
     <Compile Include="SagaPersister\MySaga.cs" />
     <Compile Include="SagaPersister\SessionFactoryHelper.cs" />
     <Compile Include="SagaPersister\SQLiteConfiguration.cs" />
@@ -109,6 +109,7 @@
     <Compile Include="TimeoutPersister\InMemoryDBFixture.cs" />
     <Compile Include="TimeoutPersister\When_fetching_timeouts_from_storage.cs" />
     <Compile Include="TimeoutPersister\When_removing_timeouts_from_the_storage.cs" />
+    <Compile Include="SagaPersister\When_automapping_sagas_with_different_correlation_properties.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="hibernate.cfg.xml">

--- a/src/NServiceBus.NHibernate.Tests/SagaPersister/InMemoryFixture.cs
+++ b/src/NServiceBus.NHibernate.Tests/SagaPersister/InMemoryFixture.cs
@@ -1,36 +1,49 @@
-namespace NServiceBus.SagaPersisters.NHibernate.Tests
+﻿namespace NServiceBus.NHibernate.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
-    using AutoPersistence;
     using global::NHibernate;
+    using global::NHibernate.Cfg;
     using global::NHibernate.Tool.hbm2ddl;
+    using NServiceBus.SagaPersisters.NHibernate;
+    using NServiceBus.SagaPersisters.NHibernate.AutoPersistence;
     using NServiceBus.Sagas;
     using NUnit.Framework;
+    using Environment = global::NHibernate.Cfg.Environment;
 
-    class InMemoryFixture<T> where T : Saga
+    abstract class InMemoryFixture
     {
-        protected SagaPersister SagaPersister;
-        protected ISessionFactory SessionFactory;
-        protected string ConnectionString;
+        protected abstract Type[] SagaTypes { get; }
 
         [SetUp]
         public void SetUp()
         {
             ConnectionString = $@"Data Source={Path.GetTempFileName()};New=True;";
 
-            var configuration = new global::NHibernate.Cfg.Configuration()
+            var configuration = new Configuration()
                 .AddProperties(new Dictionary<string, string>
                 {
-                    { "dialect", dialect },
-                    { global::NHibernate.Cfg.Environment.ConnectionString, ConnectionString }
+                    {"dialect", dialect},
+                    {Environment.ConnectionString, ConnectionString}
                 });
 
             var metaModel = new SagaMetadataCollection();
-            metaModel.Initialize(new[] { typeof(T) });
-            var metadata = metaModel.Find(typeof(T));
 
-            var modelMapper = new SagaModelMapper(metaModel, new[] { metadata.SagaEntityType });
+            metaModel.Initialize(SagaTypes);
+
+            var sagaDataTypes = new List<Type>();
+            using (var enumerator = metaModel.GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    sagaDataTypes.Add(enumerator.Current.SagaEntityType);
+                }
+            }
+
+            sagaDataTypes.Add(typeof(ContainSagaData));
+
+            var modelMapper = new SagaModelMapper(metaModel, sagaDataTypes);
 
             configuration.AddMapping(modelMapper.Compile());
 
@@ -46,6 +59,11 @@ namespace NServiceBus.SagaPersisters.NHibernate.Tests
         {
             SessionFactory.Close();
         }
+
+        string ConnectionString;
+
+        protected SagaPersister SagaPersister;
+        protected ISessionFactory SessionFactory;
 
         const string dialect = "NHibernate.Dialect.SQLiteDialect";
     }

--- a/src/NServiceBus.NHibernate.Tests/SagaPersister/When_automapping_sagas_with_different_correlation_properties.cs
+++ b/src/NServiceBus.NHibernate.Tests/SagaPersister/When_automapping_sagas_with_different_correlation_properties.cs
@@ -1,0 +1,127 @@
+﻿namespace NServiceBus.NHibernate.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Sagas;
+    using NServiceBus.Testing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class When_automapping_sagas_with_different_correlation_properties : InMemoryFixture
+    {
+        protected override Type[] SagaTypes => new[]
+        {
+            typeof(FirstAutomappedSaga),
+            typeof(SecondAutomappedSaga)
+        };
+
+        [Test]
+        public async Task Value_uniqueness_should_be_enforced()
+        {
+            var firstFailed = false;
+            using (var session = SessionFactory.OpenSession())
+            using (var transaction = session.BeginTransaction())
+            {
+                var storageSession = new TestingNHibernateSynchronizedStorageSession(session);
+
+                var correlationProperty = new SagaCorrelationProperty("FirstId", "whatever");
+
+                await SagaPersister.Save(new FirstAutomappedSagaData
+                {
+                    Id = Guid.NewGuid(),
+                    FirstId = "whatever"
+                }, correlationProperty, storageSession, new ContextBag()).ConfigureAwait(false);
+
+                await SagaPersister.Save(new FirstAutomappedSagaData
+                {
+                    Id = Guid.NewGuid(),
+                    FirstId = "whatever"
+                }, correlationProperty, storageSession, new ContextBag()).ConfigureAwait(false);
+
+                try
+                {
+                    transaction.Commit();
+                }
+                catch (Exception)
+                {
+                    firstFailed = true;
+                }
+            }
+
+            var secondFailed = false;
+            using (var session = SessionFactory.OpenSession())
+            using (var transaction = session.BeginTransaction())
+            {
+                var storageSession = new TestingNHibernateSynchronizedStorageSession(session);
+
+                var correlationProperty = new SagaCorrelationProperty("SecondId", "whatever");
+
+                await SagaPersister.Save(new SecondAutomappedSagaData
+                {
+                    Id = Guid.NewGuid(),
+                    SecondId = "whatever"
+                }, correlationProperty, storageSession, new ContextBag()).ConfigureAwait(false);
+
+                await SagaPersister.Save(new SecondAutomappedSagaData
+                {
+                    Id = Guid.NewGuid(),
+                    SecondId = "whatever"
+                }, correlationProperty, storageSession, new ContextBag()).ConfigureAwait(false);
+
+                try
+                {
+                    transaction.Commit();
+                }
+                catch (Exception)
+                {
+                    secondFailed = true;
+                }
+            }
+
+            Assert.IsTrue(firstFailed);
+            Assert.IsTrue(secondFailed);
+        }
+    }
+
+    class FirstAutomappedSaga : Saga<FirstAutomappedSagaData>, IAmStartedByMessages<SomeMessage>
+    {
+        public Task Handle(SomeMessage message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<FirstAutomappedSagaData> mapper)
+        {
+            mapper.ConfigureMapping<SomeMessage>(m => m.Id).ToSaga(s => s.FirstId);
+        }
+    }
+
+    public class FirstAutomappedSagaData : ContainSagaData
+    {
+        public virtual string FirstId { get; set; }
+    }
+
+    class SecondAutomappedSaga : Saga<SecondAutomappedSagaData>, IAmStartedByMessages<SomeMessage>
+    {
+        public Task Handle(SomeMessage message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SecondAutomappedSagaData> mapper)
+        {
+            mapper.ConfigureMapping<SomeMessage>(m => m.Id).ToSaga(s => s.SecondId);
+        }
+    }
+
+    public class SecondAutomappedSagaData : ContainSagaData
+    {
+        public virtual string SecondId { get; set; }
+    }
+
+    public class SomeMessage : ICommand
+    {
+        public string Id { get; set; }
+    }
+}

--- a/src/NServiceBus.NHibernate.Tests/SagaPersister/When_persisting_a_saga_with_a_unique_property.cs
+++ b/src/NServiceBus.NHibernate.Tests/SagaPersister/When_persisting_a_saga_with_a_unique_property.cs
@@ -3,13 +3,16 @@
     using System;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using NServiceBus.NHibernate.Tests;
     using NServiceBus.Sagas;
     using NServiceBus.Testing;
     using NUnit.Framework;
 
     [TestFixture]
-    class When_persisting_a_saga_with_a_unique_property : InMemoryFixture<SomeSaga>
+    class When_persisting_a_saga_with_a_unique_property : InMemoryFixture
     {
+        protected override Type[] SagaTypes => new[] {typeof(SomeSaga)};
+
         [Test]
         public async Task The_database_should_enforce_the_uniqueness()
         {

--- a/src/NServiceBus.NHibernate.sln
+++ b/src/NServiceBus.NHibernate.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.NHibernate", "NServiceBus.NHibernate\NServiceBus.NHibernate.csproj", "{281646E3-32E0-4F4D-BCF6-1DC5EFC6C268}"
 EndProject

--- a/src/NServiceBus.NHibernate/Deduplication/NHibernateGatewayDeduplication.cs
+++ b/src/NServiceBus.NHibernate/Deduplication/NHibernateGatewayDeduplication.cs
@@ -3,9 +3,9 @@ namespace NServiceBus.Features
     using System.Threading.Tasks;
     using Deduplication.NHibernate.Config;
     using Deduplication.NHibernate;
-    using Deduplication.NHibernate.Installer;
-    using global::NHibernate.Tool.hbm2ddl;
+    using TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
+    using Installer = Deduplication.NHibernate.Installer.Installer;
 
     /// <summary>
     /// NHibernate Gateway Deduplication.
@@ -37,7 +37,7 @@ namespace NServiceBus.Features
             {
                 context.Settings.Get<Installer.SchemaUpdater>().Execute = identity =>
                 {
-                    new SchemaUpdate(config.Configuration).Execute(false, true);
+                    new OptimizedSchemaUpdate(config.Configuration).Execute(false, true);
 
                     return Task.FromResult(0);
                 };

--- a/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
+++ b/src/NServiceBus.NHibernate/Subscriptions/NHibernateSubscriptionStorage.cs
@@ -2,11 +2,11 @@ namespace NServiceBus.Features
 {
     using System;
     using System.Threading.Tasks;
-    using global::NHibernate.Tool.hbm2ddl;
+    using TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
     using Unicast.Subscriptions.NHibernate;
     using Unicast.Subscriptions.NHibernate.Config;
-    using Unicast.Subscriptions.NHibernate.Installer;
+    using Installer = Unicast.Subscriptions.NHibernate.Installer.Installer;
 
     /// <summary>
     /// NHibernate Subscription Storage
@@ -41,7 +41,7 @@ namespace NServiceBus.Features
             {
                 context.Settings.Get<Installer.SchemaUpdater>().Execute = identity =>
                 {
-                    new SchemaUpdate(config.Configuration).Execute(false, true);
+                    new OptimizedSchemaUpdate(config.Configuration).Execute(false, true);
 
                     return Task.FromResult(0);
                 };

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateStorageSession.cs
@@ -6,13 +6,13 @@ namespace NServiceBus.Features
     using System.Threading.Tasks;
     using global::NHibernate.Cfg;
     using global::NHibernate.Mapping.ByCode;
-    using global::NHibernate.Tool.hbm2ddl;
-    using NServiceBus.NHibernate.Outbox;
+    using NHibernate.Outbox;
     using global::NHibernate.Transaction;
     using NServiceBus.Outbox.NHibernate;
+    using TimeoutPersisters.NHibernate.Installer;
     using Persistence.NHibernate;
-    using Persistence.NHibernate.Installer;
     using Environment = global::NHibernate.Cfg.Environment;
+    using Installer = Persistence.NHibernate.Installer.Installer;
 
     /// <summary>
     /// NHibernate Storage Session.
@@ -76,7 +76,7 @@ namespace NServiceBus.Features
             {
                 context.Settings.Get<Installer.SchemaUpdater>().Execute = identity =>
                 {
-                    var schemaUpdate = new SchemaUpdate(config.Configuration);
+                    var schemaUpdate = new OptimizedSchemaUpdate(config.Configuration);
                     var sb = new StringBuilder();
                     schemaUpdate.Execute(s => sb.AppendLine(s), true);
 


### PR DESCRIPTION
Fixed appication of Unique constraing on saga correlation properties
Use optimized schema update to ensure correct indexes are created.