### PR TITLE
Script generator usable in a test

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/DDL.GatewayDeduplication.approved.txt
+++ b/src/NServiceBus.NHibernate.Tests/DDL.GatewayDeduplication.approved.txt
@@ -1,0 +1,9 @@
+﻿
+    
+    if exists (select * from dbo.sysobjects where id = object_id(N'GatewayDeduplication') and OBJECTPROPERTY(id, N'IsUserTable') = 1) drop table GatewayDeduplication
+    
+    create table GatewayDeduplication (
+        Id NVARCHAR(255) not null,
+       TimeReceived DATETIME null,
+       primary key (Id)
+    )

--- a/src/NServiceBus.NHibernate.Tests/DDL.MySaga.approved.txt
+++ b/src/NServiceBus.NHibernate.Tests/DDL.MySaga.approved.txt
@@ -1,0 +1,11 @@
+﻿
+    
+    if exists (select * from dbo.sysobjects where id = object_id(N'MySaga') and OBJECTPROPERTY(id, N'IsUserTable') = 1) drop table MySaga
+    
+    create table MySaga (
+        Id UNIQUEIDENTIFIER not null,
+       Originator NVARCHAR(255) null,
+       OriginalMessageId NVARCHAR(255) null,
+       UniqueId NVARCHAR(255) null unique,
+       primary key (Id)
+    )

--- a/src/NServiceBus.NHibernate.Tests/DDL.Outbox.approved.txt
+++ b/src/NServiceBus.NHibernate.Tests/DDL.Outbox.approved.txt
@@ -1,0 +1,16 @@
+﻿
+    
+    if exists (select * from dbo.sysobjects where id = object_id(N'OutboxRecord') and OBJECTPROPERTY(id, N'IsUserTable') = 1) drop table OutboxRecord
+    
+    create table OutboxRecord (
+        Id BIGINT IDENTITY NOT NULL,
+       MessageId NVARCHAR(255) not null unique,
+       Dispatched BIT not null,
+       DispatchedAt DATETIME null,
+       TransportOperations NVARCHAR(MAX) null,
+       primary key (Id)
+    )
+    
+    create index OutboxRecord_Dispatched_Idx on OutboxRecord (Dispatched)
+    
+    create index OutboxRecord_DispatchedAt_Idx on OutboxRecord (DispatchedAt)

--- a/src/NServiceBus.NHibernate.Tests/DDL.Subscriptions.approved.txt
+++ b/src/NServiceBus.NHibernate.Tests/DDL.Subscriptions.approved.txt
@@ -1,0 +1,14 @@
+﻿
+    
+    if exists (select * from dbo.sysobjects where id = object_id(N'Subscription') and OBJECTPROPERTY(id, N'IsUserTable') = 1) drop table Subscription
+    
+    create table Subscription (
+        SubscriberEndpoint VARCHAR(450) not null,
+       MessageType VARCHAR(450) not null,
+       LogicalEndpoint VARCHAR(450) null,
+       Version VARCHAR(450) null,
+       TypeName VARCHAR(450) null,
+       primary key (SubscriberEndpoint, MessageType)
+    )
+    
+    create index Subscription_TypeNameIdx on Subscription (TypeName)

--- a/src/NServiceBus.NHibernate.Tests/DDL.Timeouts.approved.txt
+++ b/src/NServiceBus.NHibernate.Tests/DDL.Timeouts.approved.txt
@@ -1,0 +1,18 @@
+﻿
+    
+    if exists (select * from dbo.sysobjects where id = object_id(N'TimeoutEntity') and OBJECTPROPERTY(id, N'IsUserTable') = 1) drop table TimeoutEntity
+    
+    create table TimeoutEntity (
+        Id UNIQUEIDENTIFIER not null,
+       Destination NVARCHAR(1024) null,
+       SagaId UNIQUEIDENTIFIER null,
+       State VARBINARY(MAX) null,
+       Endpoint NVARCHAR(440) null,
+       Time DATETIME null,
+       Headers NVARCHAR(MAX) null,
+       primary key (Id)
+    )
+    
+    create index TimeoutEntity_SagaIdIdx on TimeoutEntity (SagaId)
+    
+    create index TimeoutEntity_EndpointIdx on TimeoutEntity (Endpoint, Time)

--- a/src/NServiceBus.NHibernate.Tests/GenerateSciptsTest.cs
+++ b/src/NServiceBus.NHibernate.Tests/GenerateSciptsTest.cs
@@ -34,6 +34,24 @@ namespace NServiceBus.NHibernate.Tests
         [Test]
         [MethodImpl(MethodImplOptions.NoInlining)]
         [UseReporter(typeof(DiffReporter))]
+        public void Timeouts()
+        {
+            var script = ScriptGenerator<MsSql2012Dialect>.GenerateTimeoutStoreScript();
+            Approvals.Verify(script);
+        }
+
+        [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [UseReporter(typeof(DiffReporter))]
+        public void GatewayDeduplication()
+        {
+            var script = ScriptGenerator<MsSql2012Dialect>.GenerateGatewayDeduplicationStoreScript();
+            Approvals.Verify(script);
+        }
+
+        [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [UseReporter(typeof(DiffReporter))]
         public void MySaga()
         {
             var script = ScriptGenerator<MsSql2012Dialect>.GenerateSagaScript<MySaga>();

--- a/src/NServiceBus.NHibernate.Tests/GenerateSciptsTest.cs
+++ b/src/NServiceBus.NHibernate.Tests/GenerateSciptsTest.cs
@@ -2,6 +2,7 @@
 
 namespace NServiceBus.NHibernate.Tests
 {
+    using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using ApprovalTests;
     using ApprovalTests.Reporters;
@@ -13,6 +14,7 @@ namespace NServiceBus.NHibernate.Tests
     public class DDL
     {
         [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         [UseReporter(typeof(DiffReporter))]
         public void Outbox()
         {
@@ -21,6 +23,7 @@ namespace NServiceBus.NHibernate.Tests
         }
 
         [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         [UseReporter(typeof(DiffReporter))]
         public void Subscriptions()
         {
@@ -29,6 +32,7 @@ namespace NServiceBus.NHibernate.Tests
         }
 
         [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         [UseReporter(typeof(DiffReporter))]
         public void MySaga()
         {

--- a/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
+++ b/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
@@ -42,6 +42,18 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ApprovalTests, Version=3.0.0.0, Culture=neutral, PublicKeyToken=11bd7d124fc62e0f, processorArchitecture=MSIL">
+      <HintPath>..\packages\ApprovalTests.3.0.13\lib\net40\ApprovalTests.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ApprovalUtilities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=11bd7d124fc62e0f, processorArchitecture=MSIL">
+      <HintPath>..\packages\ApprovalUtilities.3.0.13\lib\net45\ApprovalUtilities.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ApprovalUtilities.Net45, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ApprovalUtilities.3.0.13\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Iesi.Collections.3.3.3.4001\lib\Net35\Iesi.Collections.dll</HintPath>
@@ -81,6 +93,7 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GenerateSciptsTest.cs" />
     <Compile Include="Outbox\FakeDbConnectionProvider.cs" />
     <Compile Include="Outbox\MessageIdOutboxRecord.cs" />
     <Compile Include="Outbox\GuidOutboxRecord.cs" />
@@ -123,6 +136,7 @@
     <EmbeddedResource Include="SagaPersister\TestSagaWithHbmlXmlOverride.hbm.xml" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Testing.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/NServiceBus.NHibernate.Tests/app.config
+++ b/src/NServiceBus.NHibernate.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/NServiceBus.NHibernate.Tests/packages.config
+++ b/src/NServiceBus.NHibernate.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ApprovalTests" version="3.0.13" targetFramework="net452" />
+  <package id="ApprovalUtilities" version="3.0.13" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net452" />

--- a/src/NServiceBus.NHibernate.sln
+++ b/src/NServiceBus.NHibernate.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.NHibernate", "NServiceBus.NHibernate\NServiceBus.NHibernate.csproj", "{281646E3-32E0-4F4D-BCF6-1DC5EFC6C268}"
 EndProject

--- a/src/NServiceBus.NHibernate.sln.DotSettings
+++ b/src/NServiceBus.NHibernate.sln.DotSettings
@@ -594,6 +594,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	
 	
 	

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Outbox\OutboxConfig.cs" />
     <Compile Include="Outbox\OutboxRecord.cs" />
     <Compile Include="RepeatedFailuresOverTimeCircuitBreaker.cs" />
+    <Compile Include="ScriptGenerator.cs" />
     <Compile Include="SynchronizedStorage\INHibernateSynchronizedStorageSession.cs" />
     <Compile Include="SynchronizedStorage\NHibernateAmbientTransactionSynchronizedStorageSession.cs" />
     <Compile Include="Obsoletes\NHibernateStorageContext.cs" />
@@ -132,6 +133,7 @@
     <Compile Include="Subscriptions\SubscriptionConfig.cs" />
     <Compile Include="SynchronizedStorageSessionExtensions.cs" />
     <Compile Include="TimeoutPersisters\IncorrectIndexDetector.cs" />
+    <Compile Include="TimeoutPersisters\SchemaFixUpHelper.cs" />
     <Compile Include="TimeoutPersisters\TimeoutEntityMap.cs" />
     <Compile Include="TimeoutPersisters\Installer\Installer.cs" />
     <Compile Include="TimeoutPersisters\OptimizedSchemaUpdate.cs" />

--- a/src/NServiceBus.NHibernate/SagaPersisters/NHibernateSagaStorage.cs
+++ b/src/NServiceBus.NHibernate/SagaPersisters/NHibernateSagaStorage.cs
@@ -45,16 +45,7 @@ namespace NServiceBus.Features
 
             var allSagaMetadata = settings.Get<SagaMetadataCollection>();
             var types = settings.GetAvailableTypes().Except(configuration.ClassMappings.Select(x => x.MappedClass));
-            SagaModelMapper modelMapper;
-            if (tableNamingConvention == null)
-            {
-                modelMapper = new SagaModelMapper(allSagaMetadata, types);
-            }
-            else
-            {
-                modelMapper = new SagaModelMapper(allSagaMetadata, types, tableNamingConvention);
-            }
-
+            var modelMapper = new SagaModelMapper(allSagaMetadata, types, tableNamingConvention);
             configuration.AddMapping(modelMapper.Compile());
         }
     }

--- a/src/NServiceBus.NHibernate/SagaPersisters/SagaModelMapper.cs
+++ b/src/NServiceBus.NHibernate/SagaPersisters/SagaModelMapper.cs
@@ -15,15 +15,9 @@ namespace NServiceBus.SagaPersisters.NHibernate.AutoPersistence
     {
         readonly Func<Type, string> tableNamingConvention;
 
-        public SagaModelMapper(SagaMetadataCollection allMetadata, IEnumerable<Type> typesToScan)
-            : this(allMetadata, typesToScan, DefaultTableNameConvention)
+        public SagaModelMapper(SagaMetadataCollection allMetadata, IEnumerable<Type> typesToScan, Func<Type, string> tableNamingConvention = null)
         {
-            
-        }
-
-        public SagaModelMapper(SagaMetadataCollection allMetadata, IEnumerable<Type> typesToScan, Func<Type, string> tableNamingConvention)
-        {
-            this.tableNamingConvention = tableNamingConvention;
+            this.tableNamingConvention = tableNamingConvention ?? DefaultTableNameConvention;
             Mapper = new ConventionModelMapper();
 
             this.typesToScan = typesToScan.ToList();

--- a/src/NServiceBus.NHibernate/ScriptGenerator.cs
+++ b/src/NServiceBus.NHibernate/ScriptGenerator.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.NHibernate
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using global::NHibernate.AdoNet.Util;
+    using global::NHibernate.Cfg;
+    using global::NHibernate.Dialect;
+    using global::NHibernate.Mapping.ByCode;
+    using global::NHibernate.Tool.hbm2ddl;
+    using NServiceBus.Outbox.NHibernate;
+    using NServiceBus.SagaPersisters.NHibernate.AutoPersistence;
+    using NServiceBus.Sagas;
+    using NServiceBus.TimeoutPersisters.NHibernate.Installer;
+    using Unicast.Subscriptions.NHibernate.Config;
+
+    /// <summary>
+    /// Allows offline schema generation.
+    /// </summary>
+    /// <typeparam name="T">Dialect.</typeparam>
+    public class ScriptGenerator<T>
+        where T : Dialect, new()
+    {
+        /// <summary>
+        /// Generates the table creation script for the outbox.
+        /// </summary>
+        /// <param name="outboxRecordMappingType">Optional: custom outbox record mapping class.</param>
+        public static string GenerateOutboxScript(Type outboxRecordMappingType = null)
+        {
+            return GenerateScript(outboxRecordMappingType ?? typeof(OutboxRecordMapping));
+        }
+
+        /// <summary>
+        /// Generates the table creation script for the subscription store.
+        /// </summary>
+        /// <returns></returns>
+        public static string GenerateSubscriptionStoreScript()
+        {
+            return GenerateScript(typeof(SubscriptionMap));
+        }
+
+        /// <summary>
+        /// Generates the table creation script for the saga data table
+        /// </summary>
+        /// <param name="tableNamingConvention">Optional custom table naming convention.</param>
+        /// <typeparam name="TSaga">Saga type.</typeparam>
+        public static string GenerateSagaScript<TSaga>(Func<Type, string> tableNamingConvention = null)
+            where TSaga : Saga
+        {
+            var sagaBase = typeof(TSaga).BaseType;
+            var sagaDataType = sagaBase.GetGenericArguments()[0];
+
+            var metadata = new SagaMetadataCollection();
+            metadata.Initialize(new[]
+            {
+                typeof(TSaga)
+            });
+            var typesToScan = new List<Type>
+            {
+                sagaDataType
+            };
+            var sagaDataBase = sagaDataType.BaseType;
+            while (sagaDataBase != null)
+            {
+                typesToScan.Add(sagaDataBase);
+                sagaDataBase = sagaDataBase.BaseType;
+            }
+
+            var sagaMapper = new SagaModelMapper(metadata, typesToScan, tableNamingConvention);
+
+            var config = new Configuration();
+            config.DataBaseIntegration(db => { db.Dialect<T>(); });
+            config.AddMapping(sagaMapper.Compile());
+            return GenerateScript(config);
+        }
+
+        static string GenerateScript(Type mappingType)
+        {
+            var config = new Configuration();
+            config.DataBaseIntegration(db => { db.Dialect<T>(); });
+
+            var mapper = new ModelMapper();
+            mapper.AddMapping(mappingType);
+            config.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities());
+
+            return GenerateScript(config);
+        }
+
+        static string GenerateScript(Configuration config)
+        {
+            var dialect = new T();
+            var export = new SchemaExport(config);
+            var fixUpHelper = new SchemaFixUpHelper(config, dialect);
+            var formatter = FormatStyle.Ddl.Formatter;
+            var script = new StringBuilder();
+            export.Create(s => script.Append(formatter.Format(fixUpHelper.FixUp(s))), false);
+            return script.ToString();
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate/ScriptGenerator.cs
+++ b/src/NServiceBus.NHibernate/ScriptGenerator.cs
@@ -8,9 +8,11 @@
     using global::NHibernate.Dialect;
     using global::NHibernate.Mapping.ByCode;
     using global::NHibernate.Tool.hbm2ddl;
+    using NServiceBus.Deduplication.NHibernate.Config;
     using NServiceBus.Outbox.NHibernate;
     using NServiceBus.SagaPersisters.NHibernate.AutoPersistence;
     using NServiceBus.Sagas;
+    using NServiceBus.TimeoutPersisters.NHibernate.Config;
     using NServiceBus.TimeoutPersisters.NHibernate.Installer;
     using Unicast.Subscriptions.NHibernate.Config;
 
@@ -37,6 +39,24 @@
         public static string GenerateSubscriptionStoreScript()
         {
             return GenerateScript(typeof(SubscriptionMap));
+        }
+
+        /// <summary>
+        /// Generates the table creation script for the timeout store.
+        /// </summary>
+        /// <returns></returns>
+        public static string GenerateTimeoutStoreScript()
+        {
+            return GenerateScript(typeof(TimeoutEntityMap));
+        }
+
+        /// <summary>
+        /// Generates the table creation script for the Gateway deduplication store.
+        /// </summary>
+        /// <returns></returns>
+        public static string GenerateGatewayDeduplicationStoreScript()
+        {
+            return GenerateScript(typeof(DeduplicationMessageMap));
         }
 
         /// <summary>

--- a/src/NServiceBus.NHibernate/TimeoutPersisters/SchemaFixUpHelper.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/SchemaFixUpHelper.cs
@@ -1,0 +1,48 @@
+namespace NServiceBus.TimeoutPersisters.NHibernate.Installer
+{
+    using System.Collections.Generic;
+    using global::NHibernate.Cfg;
+    using global::NHibernate.Dialect;
+    using Config;
+
+    class SchemaFixUpHelper
+    {
+        static List<string> dialectScopes = new List<string>
+        {
+            typeof(MsSql2005Dialect).FullName,
+            typeof(MsSql2008Dialect).FullName,
+            typeof(MsSql2012Dialect).FullName
+        };
+
+        Configuration configuration;
+        Dialect dialect;
+
+        public SchemaFixUpHelper(Configuration configuration, Dialect dialect)
+        {
+            this.configuration = configuration;
+            this.dialect = dialect;
+        }
+
+        public string FixUp(string item)
+        {
+            var timeoutEntityMapping = configuration.GetClassMapping(typeof(TimeoutEntity));
+            var shouldOptimizeTimeoutEntity = timeoutEntityMapping != null;
+
+            var updateSqlStatement = item;
+            if (dialectScopes.Contains(dialect.GetType().FullName) && shouldOptimizeTimeoutEntity)
+            {
+                var qualifiedTimeoutEntityTableName = timeoutEntityMapping.Table.GetQualifiedName(dialect);
+
+                if (updateSqlStatement.StartsWith($"create table {qualifiedTimeoutEntityTableName}"))
+                {
+                    updateSqlStatement = updateSqlStatement.Replace("primary key (Id)", "primary key nonclustered (Id)");
+                }
+                else if (updateSqlStatement.StartsWith($"create index {TimeoutEntityMap.EndpointIndexName}"))
+                {
+                    updateSqlStatement = updateSqlStatement.Replace($"create index {TimeoutEntityMap.EndpointIndexName}", $"create clustered index {TimeoutEntityMap.EndpointIndexName}");
+                }
+            }
+            return updateSqlStatement;
+        }
+    }
+}


### PR DESCRIPTION
Adds `ScriptGenerator` class that can be used in tests to generate table creation scripts.

The `DDL.cs` test contains an example of how this would be used by users to generate their schemas as part of the build process.