### PR TITLE
Add acceptance tests to test special character headers

### DIFF
--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/App_Packages/NSB.AcceptanceTests.6.1.1/DelayedDelivery/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/App_Packages/NSB.AcceptanceTests.6.1.1/DelayedDelivery/When_using_special_characters_in_headers.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_using_special_characters_in_headers : NServiceBusAcceptanceTest
+    {
+        readonly Dictionary<string, string> specialHeaders = new Dictionary<string, string>
+        {
+            { "a-B1", "a-B" },
+            { "a-B2", "a-ɤϡ֎ᾣ♥-b" },
+            { "a-ɤϡ֎ᾣ♥-B3", "a-B" },
+            { "a-B4", "a-\U0001F60D-b" },
+            { "a-\U0001F605-B5", "a-B" },
+            { "a-B6", "a-😍-b" },
+            { "a-😅-B7", "a-B" },
+        };
+
+        [Test]
+        public async Task Should_store_unicode_characters_in_timeout_persistence_for_delayed_messages()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointHandlingDelayedMessages>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteToThisEndpoint();
+                        options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
+                        foreach (var specialHeader in specialHeaders)
+                        {
+                            options.SetHeader(specialHeader.Key, specialHeader.Value);
+                        }
+                        return s.Send(new DelayedMessage(), options);
+                    }))
+                .Done(c => c.ReceivedMessageHeaders != null)
+                .Run();
+
+            Assert.IsNotEmpty(context.ReceivedMessageHeaders);
+            CollectionAssert.IsSupersetOf(context.ReceivedMessageHeaders, specialHeaders);
+        }
+
+        class Context : ScenarioContext
+        {
+            public IReadOnlyDictionary<string, string> ReceivedMessageHeaders { get; set; }
+        }
+
+        class EndpointHandlingDelayedMessages : EndpointConfigurationBuilder
+        {
+            public EndpointHandlingDelayedMessages()
+            {
+                EndpointSetup<DefaultServer>(e => e.EnableFeature<TimeoutManager>());
+            }
+
+            class DelayedMessageHandler : IHandleMessages<DelayedMessage>
+            {
+                Context testContext;
+
+                public DelayedMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(DelayedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessageHeaders = context.MessageHeaders;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class DelayedMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/App_Packages/NSB.AcceptanceTests.6.1.1/Recoverability/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/App_Packages/NSB.AcceptanceTests.6.1.1/Recoverability/When_using_special_characters_in_headers.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.Recoverability
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_using_special_characters_in_headers : NServiceBusAcceptanceTest
+    {
+        readonly Dictionary<string, string> specialHeaders = new Dictionary<string, string>
+        {
+            { "a-B1", "a-B" },
+            { "a-B2", "a-ɤϡ֎ᾣ♥-b" },
+            { "a-ɤϡ֎ᾣ♥-B3", "a-B" },
+            { "a-B4", "a-\U0001F60D-b" },
+            { "a-\U0001F605-B5", "a-B" },
+            { "a-B6", "a-😍-b" },
+            { "a-😅-B7", "a-B" },
+        };
+
+        [Test]
+        public async Task Should_store_unicode_characters_in_timeout_manager_for_delayed_retries()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointHandlingDelayedMessages>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteToThisEndpoint();
+                        options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
+                        foreach (var specialHeader in specialHeaders)
+                        {
+                            options.SetHeader(specialHeader.Key, specialHeader.Value);
+                        }
+                        return s.Send(new FailingMessage(), options);
+                    }))
+                .Done(c => c.ReceivedMessageHeaders != null)
+                .Run();
+
+            Assert.IsNotEmpty(context.ReceivedMessageHeaders);
+            CollectionAssert.IsSupersetOf(context.ReceivedMessageHeaders, Enumerable.Empty<KeyValuePair<string, string>>());
+        }
+
+        class Context : ScenarioContext
+        {
+            public IReadOnlyDictionary<string, string> ReceivedMessageHeaders { get; set; }
+        }
+
+        class EndpointHandlingDelayedMessages : EndpointConfigurationBuilder
+        {
+            public EndpointHandlingDelayedMessages()
+            {
+                EndpointSetup<DefaultServer>(e =>
+                {
+                    e.EnableFeature<TimeoutManager>();
+                    e.Recoverability()
+                        .Immediate(ir => ir
+                            .NumberOfRetries(0))
+                        .Delayed(dr => dr
+                            .NumberOfRetries(1)
+                            .TimeIncrease(TimeSpan.FromSeconds(3)));
+                });
+            }
+
+            class DelayedMessageHandler : IHandleMessages<FailingMessage>
+            {
+                Context testContext;
+
+                public DelayedMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(FailingMessage message, IMessageHandlerContext context)
+                {
+                    string delayedRetryAttempt;
+                    if (context.MessageHeaders.TryGetValue(Headers.DelayedRetries, out delayedRetryAttempt))
+                    {
+                        testContext.ReceivedMessageHeaders = context.MessageHeaders;
+                        return Task.FromResult(0);
+                    }
+
+                    throw new Exception("require delayed retry");
+                }
+            }
+        }
+
+        public class FailingMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
@@ -139,6 +139,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\DataBus\When_using_custom_IDataBus.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\DelayedDelivery\When_Deferring_a_message.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\DelayedDelivery\When_deferring_a_message_to_the_past.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\DelayedDelivery\When_using_special_characters_in_headers.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\DeterministicGuid.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Encryption\When_using_encryption_with_custom_service.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Encryption\When_using_Rijndael_without_incoming_key_identifier.cs" />
@@ -205,6 +206,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Recoverability\When_message_is_moved_to_error_queue_using_dtc.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Recoverability\When_message_with_TimeToBeReceived_fails.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Recoverability\When_using_special_characters_in_headers.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Reliability\Outbox\When_a_duplicate_message_arrives.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Reliability\Outbox\When_a_message_is_audited.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Reliability\Outbox\When_blowing_up_just_after_dispatch.cs" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.1.1/DelayedDelivery/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.1.1/DelayedDelivery/When_using_special_characters_in_headers.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_using_special_characters_in_headers : NServiceBusAcceptanceTest
+    {
+        readonly Dictionary<string, string> specialHeaders = new Dictionary<string, string>
+        {
+            { "a-B1", "a-B" },
+            { "a-B2", "a-ɤϡ֎ᾣ♥-b" },
+            { "a-ɤϡ֎ᾣ♥-B3", "a-B" },
+            { "a-B4", "a-\U0001F60D-b" },
+            { "a-\U0001F605-B5", "a-B" },
+            { "a-B6", "a-😍-b" },
+            { "a-😅-B7", "a-B" },
+        };
+
+        [Test]
+        public async Task Should_store_unicode_characters_in_timeout_persistence_for_delayed_messages()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointHandlingDelayedMessages>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteToThisEndpoint();
+                        options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
+                        foreach (var specialHeader in specialHeaders)
+                        {
+                            options.SetHeader(specialHeader.Key, specialHeader.Value);
+                        }
+                        return s.Send(new DelayedMessage(), options);
+                    }))
+                .Done(c => c.ReceivedMessageHeaders != null)
+                .Run();
+
+            Assert.IsNotEmpty(context.ReceivedMessageHeaders);
+            CollectionAssert.IsSupersetOf(context.ReceivedMessageHeaders, specialHeaders);
+        }
+
+        class Context : ScenarioContext
+        {
+            public IReadOnlyDictionary<string, string> ReceivedMessageHeaders { get; set; }
+        }
+
+        class EndpointHandlingDelayedMessages : EndpointConfigurationBuilder
+        {
+            public EndpointHandlingDelayedMessages()
+            {
+                EndpointSetup<DefaultServer>(e => e.EnableFeature<TimeoutManager>());
+            }
+
+            class DelayedMessageHandler : IHandleMessages<DelayedMessage>
+            {
+                Context testContext;
+
+                public DelayedMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(DelayedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessageHeaders = context.MessageHeaders;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class DelayedMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.1.1/Recoverability/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/App_Packages/NSB.AcceptanceTests.6.1.1/Recoverability/When_using_special_characters_in_headers.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.Recoverability
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_using_special_characters_in_headers : NServiceBusAcceptanceTest
+    {
+        readonly Dictionary<string, string> specialHeaders = new Dictionary<string, string>
+        {
+            { "a-B1", "a-B" },
+            { "a-B2", "a-ɤϡ֎ᾣ♥-b" },
+            { "a-ɤϡ֎ᾣ♥-B3", "a-B" },
+            { "a-B4", "a-\U0001F60D-b" },
+            { "a-\U0001F605-B5", "a-B" },
+            { "a-B6", "a-😍-b" },
+            { "a-😅-B7", "a-B" },
+        };
+
+        [Test]
+        public async Task Should_store_unicode_characters_in_timeout_manager_for_delayed_retries()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointHandlingDelayedMessages>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteToThisEndpoint();
+                        options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
+                        foreach (var specialHeader in specialHeaders)
+                        {
+                            options.SetHeader(specialHeader.Key, specialHeader.Value);
+                        }
+                        return s.Send(new FailingMessage(), options);
+                    }))
+                .Done(c => c.ReceivedMessageHeaders != null)
+                .Run();
+
+            Assert.IsNotEmpty(context.ReceivedMessageHeaders);
+            CollectionAssert.IsSupersetOf(context.ReceivedMessageHeaders, Enumerable.Empty<KeyValuePair<string, string>>());
+        }
+
+        class Context : ScenarioContext
+        {
+            public IReadOnlyDictionary<string, string> ReceivedMessageHeaders { get; set; }
+        }
+
+        class EndpointHandlingDelayedMessages : EndpointConfigurationBuilder
+        {
+            public EndpointHandlingDelayedMessages()
+            {
+                EndpointSetup<DefaultServer>(e =>
+                {
+                    e.EnableFeature<TimeoutManager>();
+                    e.Recoverability()
+                        .Immediate(ir => ir
+                            .NumberOfRetries(0))
+                        .Delayed(dr => dr
+                            .NumberOfRetries(1)
+                            .TimeIncrease(TimeSpan.FromSeconds(3)));
+                });
+            }
+
+            class DelayedMessageHandler : IHandleMessages<FailingMessage>
+            {
+                Context testContext;
+
+                public DelayedMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(FailingMessage message, IMessageHandlerContext context)
+                {
+                    string delayedRetryAttempt;
+                    if (context.MessageHeaders.TryGetValue(Headers.DelayedRetries, out delayedRetryAttempt))
+                    {
+                        testContext.ReceivedMessageHeaders = context.MessageHeaders;
+                        return Task.FromResult(0);
+                    }
+
+                    throw new Exception("require delayed retry");
+                }
+            }
+        }
+
+        public class FailingMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -314,6 +314,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\UnicastRoutingExtensions.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\DelayedDelivery\When_using_special_characters_in_headers.cs" />
     <Compile Include="ConfigureEndpointNHibernatePersistence.cs" />
     <Compile Include="EndpointConfigurer.cs" />
     <Compile Include="When_using_outbox_with_transport_in_transaction_scope_mode.cs" />
@@ -323,6 +324,7 @@
     <Compile Include="When_saga_contains_nested_collection_without_parent_relation.cs" />
     <Compile Include="When_saga_contains_nested_collection.cs" />
     <Compile Include="When_saga_contains_nested_collection_with_row_version.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.1\Recoverability\When_using_special_characters_in_headers.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">


### PR DESCRIPTION
raising this as a PR to let the tests run on the different SQL servers. Feel free to pull this in or to close this once the tests ran (will be part of the acceptance tests package with the next version anyway)