### PR TITLE
[WIP] Use upgrade lock

### DIFF
--- a/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
@@ -154,10 +154,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate
             using (var session = await OpenSession(context).ConfigureAwait(false))
             {
                 var id = Guid.Parse(timeoutId);
-                var te = session.Session().QueryOver<TimeoutEntity>()
-                    .Where(x => x.Id == id)
-                    .List()
-                    .SingleOrDefault();
+                var te = session.Session().Get<TimeoutEntity>(id, LockMode.Upgrade);
 
                 var timeout = MapToTimeoutData(te);
                 return timeout;


### PR DESCRIPTION
Connects to #304 

Uses `SELECT FOR UPDATE` type of query when `Peek`ing timeouts to prevent multiple instances of the endpoint from attempting to dispatch a single timeout. Should lower the chances of stealing timeouts. Will only work in `TransactionScope` mode because only then there will be a transaction between `Peek` and `TryDelete`. In other transaction modes will behave similar to like it behaved before because the lock will be released prior to deleting.