### PR TITLE
Use AcceptanceTestingTransport to test timeout and subscription storage

### DIFF
--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0012" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0013" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.2400" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/TestSuiteConstraints.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/TestSuiteConstraints.cs
@@ -9,7 +9,7 @@
         public bool SupportsNativePubSub => true;
         public bool SupportsNativeDeferral => true;
         public bool SupportsOutbox => true;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointLearningTransport();
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointNHibernatePersistence();
     }
 }

--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/TestSuiteConstraints.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/TestSuiteConstraints.cs
@@ -6,8 +6,8 @@
     {
         public bool SupportsDtc => false;
         public bool SupportsCrossQueueTransactions => true;
-        public bool SupportsNativePubSub => true;
-        public bool SupportsNativeDeferral => true;
+        public bool SupportsNativePubSub => false;
+        public bool SupportsNativeDeferral => false;
         public bool SupportsOutbox => true;
         public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointNHibernatePersistence();

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -10,9 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0012" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="3.0.0-beta0005" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.1.0-acceptance-test-0001" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0013" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0012" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="3.0.0-beta0005" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.1.0-acceptance-test-0001" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0013" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0012" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="3.0.0-beta0005" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.1.0-acceptance-test-0001" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>

--- a/src/NServiceBus.NHibernate.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/TestSuiteConstraints.cs
@@ -6,10 +6,10 @@
     {
         public bool SupportsDtc => false;
         public bool SupportsCrossQueueTransactions => true;
-        public bool SupportsNativePubSub => true;
-        public bool SupportsNativeDeferral => true;
+        public bool SupportsNativePubSub => false;
+        public bool SupportsNativeDeferral => false;
         public bool SupportsOutbox => true;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointLearningTransport();
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureAcceptanceTestingTransport(false, false);
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointNHibernatePersistence();
     }
 }

--- a/src/NServiceBus.NHibernate.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/TestSuiteConstraints.cs
@@ -9,7 +9,7 @@
         public bool SupportsNativePubSub => false;
         public bool SupportsNativeDeferral => false;
         public bool SupportsOutbox => true;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureAcceptanceTestingTransport(false, false);
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointNHibernatePersistence();
     }
 }


### PR DESCRIPTION
using the `AcceptanceTestingTransport` instead of the learning transport to disable native pubsub and native delayed delivery. This allows the acceptance tests to test the actual storage options.