### PR TITLE
Ramon's timeout improvements, re-applied

### DIFF
--- a/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
@@ -74,9 +74,9 @@ namespace NServiceBus.TimeoutPersisters.NHibernate
                         .Where(x => x.Endpoint == EndpointName && x.Time > now)
                         .OrderBy(x => x.Time).Asc
                         .Take(1)
-                        .SingleOrDefault();
+                        .SingleOrDefault<DateTime?>();
 
-                    var nextTimeToRunQuery = startOfNextChunk?.Time ?? DateTime.UtcNow.AddMinutes(10);
+                    var nextTimeToRunQuery = startOfNextChunk ?? DateTime.UtcNow.AddMinutes(10);
 
                     tx.Commit();
                     return Task.FromResult(new TimeoutsChunk(results, nextTimeToRunQuery));

--- a/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
+++ b/src/NServiceBus.NHibernate/TimeoutPersisters/TimeoutPersister.cs
@@ -73,6 +73,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate
                     var startOfNextChunk = session.QueryOver<TimeoutEntity>()
                         .Where(x => x.Endpoint == EndpointName && x.Time > now)
                         .OrderBy(x => x.Time).Asc
+                        .Select(x => x.Time)
                         .Take(1)
                         .SingleOrDefault<DateTime?>();
 


### PR DESCRIPTION
I've reviewed the changes in https://github.com/Particular/NServiceBus.NHibernate/pull/113 compared to the current code in the release branch. Result is this PR which adds one missing change: better use of the index in the query for next time to look for timeouts.

Replaces https://github.com/Particular/NServiceBus.NHibernate/pull/113