### PR TITLE
Fix build error caused by ApprovalTests

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
+++ b/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="3.*" />
+    <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="5.0.6" />
     <PackageReference Include="NServiceBus" Version="7.0.0-rc0001" />


### PR DESCRIPTION
The latest version of ApprovalTests has introduced a breaking change in a patch version, so we need to lock to the 3.0.13 release instead.

@ramonsmits This should be merged before #332 to fix the build error.