### PR TITLE
Override outbox table and schema names

### DIFF
--- a/src/NServiceBus.NHibernate.AcceptanceTests/When_receiving_a_message_with_customized_outbox_table_name.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/When_receiving_a_message_with_customized_outbox_table_name.cs
@@ -9,8 +9,6 @@
     using global::NHibernate.Driver;
     using global::NHibernate.SqlCommand;
     using NHibernate.Outbox;
-    using NServiceBus.Outbox.NHibernate;
-    using Settings;
     using NUnit.Framework;
     using Persistence;
     using Environment = global::NHibernate.Cfg.Environment;

--- a/src/NServiceBus.NHibernate.AcceptanceTests/When_receiving_a_message_with_customized_outbox_table_name.cs
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/When_receiving_a_message_with_customized_outbox_table_name.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
-    using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -8,8 +7,6 @@
     using global::NHibernate.Cfg;
     using global::NHibernate.Dialect;
     using global::NHibernate.Driver;
-    using global::NHibernate.Mapping.ByCode;
-    using global::NHibernate.Mapping.ByCode.Conformist;
     using global::NHibernate.SqlCommand;
     using NHibernate.Outbox;
     using NServiceBus.Outbox.NHibernate;
@@ -18,7 +15,7 @@
     using Persistence;
     using Environment = global::NHibernate.Cfg.Environment;
 
-    public class When_receiving_a_message_with_customized_outbox_record_mapping : NServiceBusAcceptanceTest
+    public class When_receiving_a_message_with_customized_outbox_table_name : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_handle_it()
@@ -37,14 +34,14 @@
 
                         var persistence = configuration.UsePersistence<NHibernatePersistence>();
                         persistence.UseConfiguration(cfg);
-                        persistence.UseOutboxRecord<MessageIdOutboxRecord, MessageIdOutboxRecordMapping>();
+                        persistence.CustomizeOutboxTableName("MyOutbox", "dbo");
                     })
                     .When(session => session.SendLocal(new PlaceOrder())))
-                .Done(c => c.OrderAckReceived == 1)
+                .Done(c => c.Done)
                 .Run();
 
-            Assert.AreEqual(1, result.OrderAckReceived);
-            Assert.IsTrue(result.CorrectTableNameDetected);
+            Assert.IsTrue(result.Done);
+            StringAssert.StartsWith("INSERT INTO dbo.MyOutbox", result.OutboxTableInsert);
         }
 
         class LoggingInterceptor : EmptyInterceptor
@@ -58,9 +55,9 @@
 
             public override SqlString OnPrepareStatement(SqlString sql)
             {
-                if (sql.StartsWithCaseInsensitive("insert into MessageIdOutboxRecordMapping"))
+                if (sql.StartsWithCaseInsensitive("insert into "))
                 {
-                    context.CorrectTableNameDetected = true;
+                    context.OutboxTableInsert = sql.ToString();
                 }
                 return sql;
             }
@@ -68,8 +65,8 @@
 
         class Context : ScenarioContext
         {
-            public int OrderAckReceived { get; set; }
-            public bool CorrectTableNameDetected { get; set; }
+            public bool Done { get; set; }
+            public string OutboxTableInsert { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -86,10 +83,7 @@
             {
                 public Task Handle(PlaceOrder message, IMessageHandlerContext context)
                 {
-                    return context.SendLocal(new SendOrderAcknowledgement
-                    {
-                        MessageId = context.MessageId
-                    });
+                    return context.SendLocal(new SendOrderAcknowledgement());
                 }
             }
 
@@ -97,17 +91,9 @@
             {
                 public Context Context { get; set; }
 
-                public ReadOnlySettings Settings { get; set; }
-
                 public Task Handle(SendOrderAcknowledgement message, IMessageHandlerContext context)
                 {
-                    var session = context.SynchronizedStorageSession.Session();
-                    var recordId = Settings.EndpointName() + "/" + message.MessageId;
-                    var record = session.Get<MessageIdOutboxRecord>(recordId);
-                    if (record != null)
-                    {
-                        Context.OrderAckReceived++;
-                    }
+                    Context.Done = true;
                     return Task.FromResult(0);
                 }
             }
@@ -119,31 +105,6 @@
 
         public class SendOrderAcknowledgement : IMessage
         {
-            public string MessageId { get; set; }
-        }
-
-        class MessageIdOutboxRecord : IOutboxRecord
-        {
-            public virtual string MessageId { get; set; }
-            public virtual bool Dispatched { get; set; }
-            public virtual DateTime? DispatchedAt { get; set; }
-            public virtual string TransportOperations { get; set; }
-        }
-
-        class MessageIdOutboxRecordMapping : ClassMapping<MessageIdOutboxRecord>
-        {
-            public MessageIdOutboxRecordMapping()
-            {
-                Table("MessageIdOutboxRecordMapping");
-                EntityName("MessageIdOutboxRecord");
-                Id(x => x.MessageId, m => m.Generator(Generators.Assigned));
-                Property(p => p.Dispatched, pm =>
-                {
-                    pm.Column(c => c.NotNullable(true));
-                });
-                Property(p => p.DispatchedAt);
-                Property(p => p.TransportOperations, pm => pm.Type(NHibernateUtil.StringClob));
-            }
         }
     }
 }

--- a/src/NServiceBus.NHibernate.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.NHibernate.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -29,6 +29,7 @@ namespace NServiceBus.NHibernate.Outbox
 {
     public class static OutboxConfig
     {
+        public static NServiceBus.PersistenceExtensions<NServiceBus.NHibernatePersistence> CustomizeOutboxTableName(this NServiceBus.PersistenceExtensions<NServiceBus.NHibernatePersistence> persistenceConfiguration, string outboxTableName, string outboxSchemaName = null) { }
         public static NServiceBus.PersistenceExtensions<NServiceBus.NHibernatePersistence> UseOutboxRecord<TEntity, TMapping>(this NServiceBus.PersistenceExtensions<NServiceBus.NHibernatePersistence> persistenceConfiguration)
             where TEntity :  class, NServiceBus.Outbox.NHibernate.IOutboxRecord, new ()
             where TMapping : NHibernate.Mapping.ByCode.Conformist.ClassMapping<TEntity> { }

--- a/src/NServiceBus.NHibernate/Outbox/OutboxConfig.cs
+++ b/src/NServiceBus.NHibernate/Outbox/OutboxConfig.cs
@@ -31,21 +31,11 @@
         /// </summary>
         /// <param name="persistenceConfiguration">The NHibernate persister configuration instance.</param>
         /// <param name="outboxTableName">Table name to use for outbox records.</param>
+        /// <param name="outboxSchemaName">Schema to use for the outbox table (optional, defaults to the default schema).</param>
         /// <returns>The NHibernate configuration.</returns>
-        public static PersistenceExtensions<NHibernatePersistence> UseOutboxTableName(this PersistenceExtensions<NHibernatePersistence> persistenceConfiguration, string outboxTableName)
+        public static PersistenceExtensions<NHibernatePersistence> CustomizeOutboxTableName(this PersistenceExtensions<NHibernatePersistence> persistenceConfiguration, string outboxTableName, string outboxSchemaName = null)
         {
             persistenceConfiguration.GetSettings().Set(NHibernateStorageSession.OutboxTableNameSettingsKey, outboxTableName);
-            return persistenceConfiguration;
-        }
-
-        /// <summary>
-        /// Assign a custom schema name for the outbox record.
-        /// </summary>
-        /// <param name="persistenceConfiguration">The NHibernate persister configuration instance.</param>
-        /// <param name="outboxSchemaName">Schema to use for outbox table.</param>
-        /// <returns>The NHibernate configuration.</returns>
-        public static PersistenceExtensions<NHibernatePersistence> UseOutboxSchemaName(this PersistenceExtensions<NHibernatePersistence> persistenceConfiguration, string outboxSchemaName)
-        {
             persistenceConfiguration.GetSettings().Set(NHibernateStorageSession.OutboxSchemaNameSettingsKey, outboxSchemaName);
             return persistenceConfiguration;
         }

--- a/src/NServiceBus.NHibernate/Outbox/OutboxConfig.cs
+++ b/src/NServiceBus.NHibernate/Outbox/OutboxConfig.cs
@@ -2,6 +2,7 @@
 {
     using global::NHibernate.Mapping.ByCode.Conformist;
     using Configuration.AdvancedExtensibility;
+    using Features;
     using NServiceBus.Outbox.NHibernate;
 
     /// <summary>
@@ -12,13 +13,40 @@
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="persistenceConfiguration"></param>
+        /// <param name="persistenceConfiguration">The NHibernate persister configuration instance.</param>
+        /// <typeparam name="TEntity">Outbox record entity type.</typeparam>
+        /// <typeparam name="TMapping">Outbox record entity type class mapping type.</typeparam>
+        /// <returns>The NHibernate configuration.</returns>
         public static PersistenceExtensions<NHibernatePersistence> UseOutboxRecord<TEntity, TMapping>(this PersistenceExtensions<NHibernatePersistence> persistenceConfiguration)
             where TEntity : class, IOutboxRecord, new()
             where TMapping : ClassMapping<TEntity>
         {
             persistenceConfiguration.GetSettings().Set<IOutboxPersisterFactory>(new OutboxPersisterFactory<TEntity>());
-            persistenceConfiguration.GetSettings().Set("NServiceBus.NHibernate.OutboxMapping", typeof(TMapping));
+            persistenceConfiguration.GetSettings().Set(NHibernateStorageSession.OutboxMappingSettingsKey, typeof(TMapping));
+            return persistenceConfiguration;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="persistenceConfiguration">The NHibernate persister configuration instance.</param>
+        /// <param name="outboxTableName">Table name to use for outbox records.</param>
+        /// <returns>The NHibernate configuration.</returns>
+        public static PersistenceExtensions<NHibernatePersistence> UseOutboxTableName(this PersistenceExtensions<NHibernatePersistence> persistenceConfiguration, string outboxTableName)
+        {
+            persistenceConfiguration.GetSettings().Set(NHibernateStorageSession.OutboxTableNameSettingsKey, outboxTableName);
+            return persistenceConfiguration;
+        }
+
+        /// <summary>
+        /// Assign a custom schema name for the outbox record.
+        /// </summary>
+        /// <param name="persistenceConfiguration">The NHibernate persister configuration instance.</param>
+        /// <param name="outboxSchemaName">Schema to use for outbox table.</param>
+        /// <returns>The NHibernate configuration.</returns>
+        public static PersistenceExtensions<NHibernatePersistence> UseOutboxSchemaName(this PersistenceExtensions<NHibernatePersistence> persistenceConfiguration, string outboxSchemaName)
+        {
+            persistenceConfiguration.GetSettings().Set(NHibernateStorageSession.OutboxSchemaNameSettingsKey, outboxSchemaName);
             return persistenceConfiguration;
         }
     }


### PR DESCRIPTION
I revived old PR by @ramonsmits . Added tests and merged the table and schema API calls into one method that overrides both (schema being optional).