### PR TITLE
Support ReadOnlyMemory<byte> in transport operations

### DIFF
--- a/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-Oracle/NServiceBus.NHibernate.AcceptanceTests-Oracle.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NHibernate" Version="5.3.9" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1896" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="21.3.0" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NHibernate" Version="5.3.9" />
-    <PackageReference Include="NServiceBus.SqlServer" Version="7.0.0-alpha.382" />
+    <PackageReference Include="NServiceBus.SqlServer" Version="7.0.0-alpha.388" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests/NServiceBus.NHibernate.AcceptanceTests-SqlTransportTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NHibernate" Version="5.3.9" />
     <PackageReference Include="NServiceBus.SqlServer" Version="7.0.0-alpha.382" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1896" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.AcceptanceTests/NServiceBus.NHibernate.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NHibernate" Version="5.3.9" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1896" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/src/NServiceBus.NHibernate.PersistenceTests/NServiceBus.NHibernate.PersistenceTests.csproj
+++ b/src/NServiceBus.NHibernate.PersistenceTests/NServiceBus.NHibernate.PersistenceTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NHibernate" Version="5.3.9" />
-    <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="8.0.0-alpha.1896" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.PersistenceTests.Sources" Version="8.0.0-alpha.1897" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
+++ b/src/NServiceBus.NHibernate.Tests/NServiceBus.NHibernate.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NHibernate" Version="5.3.9" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1896" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />

--- a/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
+++ b/src/NServiceBus.NHibernate/NServiceBus.NHibernate.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Public dependencies">
-    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1896, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1897, 9.0.0)" />
     <PackageReference Include="NHibernate" Version="[5.3.0, 6.0.0)" />
   </ItemGroup>
 

--- a/src/NServiceBus.NHibernate/Outbox/ConcurrencyControlStrategy.cs
+++ b/src/NServiceBus.NHibernate/Outbox/ConcurrencyControlStrategy.cs
@@ -20,7 +20,7 @@
             }
             var operations = outboxMessage.TransportOperations.Select(t => new OutboxOperation
             {
-                Message = t.Body,
+                Message = t.Body.ToArray(),
                 Headers = t.Headers,
                 MessageId = t.MessageId,
                 Options = t.Options != null ? new Dictionary<string, string>(t.Options) : new Dictionary<string, string>(),


### PR DESCRIPTION
Implementation must use `.ToArray` that allocates a new array.

Unfortunately the DataContractJsonSerializer does not seem to support any of the low allocation memory types from System.Memory.

Strategies tried but non working

- ReadOnlyMemory<byte> property
- MemoryMarshal.TryGetArray, but destination is `byte[]` and gets the whole buffer. No way to get only the actual byte[] segment
- ReadOnlySpan<byte> property
- IEnumerable<byte>
