### PR TITLE
Fix synchronized session dispose

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/SynchronizedStorage/NHibernateSynchronizedStorageSessionTests.cs
+++ b/src/NServiceBus.NHibernate.Tests/SynchronizedStorage/NHibernateSynchronizedStorageSessionTests.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus.NHibernate.Tests.SynchronizedStorage
+{
+    using NHibernate.SynchronizedStorage;
+    using NUnit.Framework;
+    using Persistence.NHibernate;
+
+    [TestFixture]
+    public class NHibernateSynchronizedStorageSessionTests
+    {
+        [Test]
+        public void Should_not_throw_when_disposing_without_opened_session()
+        {
+            var synchronizedSession = new NHibernateSynchronizedStorageSession(new SessionFactoryHolder(null));
+
+            Assert.DoesNotThrow(() => synchronizedSession.Dispose());
+        }
+    }
+}

--- a/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateSynchronizedStorageSession.cs
+++ b/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateSynchronizedStorageSession.cs
@@ -22,10 +22,7 @@
         readonly ISessionFactory sessionFactory;
         INHibernateStorageSessionInternal internalSession;
 
-        public NHibernateSynchronizedStorageSession(SessionFactoryHolder sessionFactoryHolder)
-        {
-            sessionFactory = sessionFactoryHolder.SessionFactory;
-        }
+        public NHibernateSynchronizedStorageSession(SessionFactoryHolder sessionFactoryHolder) => sessionFactory = sessionFactoryHolder.SessionFactory;
 
         public ValueTask<bool> TryOpen(IOutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
         {
@@ -78,9 +75,6 @@
 
         public Task CompleteAsync(CancellationToken cancellationToken = new CancellationToken()) => internalSession.CompleteAsync(cancellationToken);
 
-        public void Dispose()
-        {
-            internalSession.Dispose();
-        }
+        public void Dispose() => internalSession?.Dispose();
     }
 }


### PR DESCRIPTION
If something during opening the session goes wrong, any `using` or `finally` block will still dispose the synchronized session, which then throws an NRE because the internal session might not have been set. This will hide the original exception that caused the open operation to fail in the first place.