### PR TITLE
Add tx session reference back to test projects

### DIFF
--- a/src/NServiceBus.NHibernate.TransactionalSession.AcceptanceTests/NServiceBus.NHibernate.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.NHibernate.TransactionalSession.AcceptanceTests/NServiceBus.NHibernate.TransactionalSession.AcceptanceTests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
+    <PackageReference Include="NServiceBus.TransactionalSession" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.NHibernate.TransactionalSession.Tests/NServiceBus.NHibernate.TransactionalSession.Tests.csproj
+++ b/src/NServiceBus.NHibernate.TransactionalSession.Tests/NServiceBus.NHibernate.TransactionalSession.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="NServiceBus.TransactionalSession" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Test projects should have an explicit reference to their upstream dependencies for dependabot to update them. This ensures that tests always run against the latest versions and verify compatibility.