### PR TITLE
Make `ScriptGenerator<T>.GenerateScript` public

### DIFF
--- a/src/NServiceBus.NHibernate.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.NHibernate.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -60,6 +60,7 @@ namespace NServiceBus.NHibernate
         public static string GenerateOutboxScript(System.Type outboxRecordMappingType = null) { }
         public static string GenerateSagaScript<TSaga>(System.Func<System.Type, string> tableNamingConvention = null)
             where TSaga : NServiceBus.Saga { }
+        public static string GenerateScript(System.Type mappingType) { }
         public static string GenerateSubscriptionStoreScript() { }
     }
 }

--- a/src/NServiceBus.NHibernate/ScriptGenerator.cs
+++ b/src/NServiceBus.NHibernate/ScriptGenerator.cs
@@ -67,6 +67,8 @@
         /// <returns></returns>
         public static string GenerateScript(Type mappingType)
         {
+            ArgumentNullException.ThrowIfNull(mappingType);
+
             var config = new Configuration();
             config.DataBaseIntegration(db => { db.Dialect<T>(); });
 

--- a/src/NServiceBus.NHibernate/ScriptGenerator.cs
+++ b/src/NServiceBus.NHibernate/ScriptGenerator.cs
@@ -63,7 +63,7 @@
         /// <summary>
         /// Generates the table creation script for a mapping class.
         /// </summary>
-        /// <param name="mappingType"></param>
+        /// <param name="mappingType">The NHibernate mapping class.</param>
         /// <returns></returns>
         public static string GenerateScript(Type mappingType)
         {

--- a/src/NServiceBus.NHibernate/ScriptGenerator.cs
+++ b/src/NServiceBus.NHibernate/ScriptGenerator.cs
@@ -24,18 +24,12 @@
         /// Generates the table creation script for the outbox.
         /// </summary>
         /// <param name="outboxRecordMappingType">Optional: custom outbox record mapping class.</param>
-        public static string GenerateOutboxScript(Type outboxRecordMappingType = null)
-        {
-            return GenerateScript(outboxRecordMappingType ?? typeof(OutboxRecordMapping));
-        }
+        public static string GenerateOutboxScript(Type outboxRecordMappingType = null) => GenerateScript(outboxRecordMappingType ?? typeof(OutboxRecordMapping));
 
         /// <summary>
         /// Generates the table creation script for the subscription store.
         /// </summary>
-        public static string GenerateSubscriptionStoreScript()
-        {
-            return GenerateScript(typeof(SubscriptionMap));
-        }
+        public static string GenerateSubscriptionStoreScript() => GenerateScript(typeof(SubscriptionMap));
 
         /// <summary>
         /// Generates the table creation script for the saga data table
@@ -66,7 +60,12 @@
             return GenerateScript(config);
         }
 
-        static string GenerateScript(Type mappingType)
+        /// <summary>
+        /// Generates the table creation script for a mapping class.
+        /// </summary>
+        /// <param name="mappingType"></param>
+        /// <returns></returns>
+        public static string GenerateScript(Type mappingType)
         {
             var config = new Configuration();
             config.DataBaseIntegration(db => { db.Dialect<T>(); });


### PR DESCRIPTION
The [NHibernate multitenant sample](https://docs.particular.net/samples/multi-tenant/nhibernate/) uses a public, but as yet undocumented API.

It is also misusing the API since it calls the `GenerateOutboxScript(Type)` method to generate the SQL script for the `Order` mapping, but this mapping is unrelated to the outbox.

There is a `GenerateScript(Type)` method that would be more suitable as a general script generator, but up until now it has not been public.

Refer to https://docs.particular.net/persistence/nhibernate/#generating-scripts-for-deployment-use-scriptgeneratort-api