### PR TITLE
Remove tag parameter from Oracle setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
         uses: Particular/setup-oracle-action@v2.0.0
         with:
           connection-string-name: OracleConnectionString
-          tag: NHibernatePersistence
           registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
           registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Run tests


### PR DESCRIPTION
Removed 'tag' parameter from Oracle setup step. Follow up of https://github.com/Particular/NServiceBus.NHibernate/pull/1469